### PR TITLE
Settings: import/export preferences as JSON

### DIFF
--- a/app/src/main/java/com/rrajath/grove/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/rrajath/grove/settings/SettingsRepository.kt
@@ -105,6 +105,37 @@ class SettingsRepository(private val context: Context) {
             ?.toMap()
             ?: emptyMap()
 
+    private fun encodeModes(map: Map<String, String>): String =
+        map.entries.joinToString(";") { "${it.key}=${it.value}" }
+
+    /**
+     * Bulk-write an imported settings document in one transaction. Leaves the
+     * device-specific vault URI and onboarding flag alone — those don't travel
+     * with an export (see [SettingsSerialization]).
+     */
+    suspend fun applyImported(s: GroveSettings) {
+        context.settingsDataStore.edit { p ->
+            p[Keys.theme] = s.theme.storageKey
+            p[Keys.fontSize] = s.fontSize.storageKey
+            p[Keys.noteOpenMode] = s.defaultNoteOpenMode.storageKey
+            p[Keys.syncMode] = s.syncMode.storageKey
+            p[Keys.periodicSyncMinutes] = s.periodicSyncMinutes
+            p[Keys.todoKeywords] = s.todoKeywords
+            if (s.defaultPriority == null) p.remove(Keys.defaultPriority)
+            else p[Keys.defaultPriority] = s.defaultPriority.toString()
+            p[Keys.addIdToNewNotes] = s.addIdToNewNotes
+            p[Keys.addCreatedToNewNotes] = s.addCreatedToNewNotes
+            p[Keys.notebookModes] = encodeModes(s.notebookModes)
+            p[Keys.notebookIcons] = encodeModes(s.notebookIcons)
+            p[Keys.notebookColors] = encodeModes(s.notebookColors)
+            p[Keys.captureNotification] = s.captureNotification
+            p[Keys.shareTargetFile] = s.shareTargetFile
+            p[Keys.showTagsInOutline] = s.showTagsInOutline
+            p[Keys.showTimestampsInOutline] = s.showTimestampsInOutline
+            p[Keys.showKeywordsInOutline] = s.showKeywordsInOutline
+        }
+    }
+
     suspend fun setTheme(theme: ThemePreference) {
         context.settingsDataStore.edit { it[Keys.theme] = theme.storageKey }
     }
@@ -176,7 +207,7 @@ class SettingsRepository(private val context: Context) {
         context.settingsDataStore.edit { prefs ->
             val current = decodeModes(prefs[Keys.notebookModes]).toMutableMap()
             current[fileName] = mode.storageKey
-            prefs[Keys.notebookModes] = current.entries.joinToString(";") { "${it.key}=${it.value}" }
+            prefs[Keys.notebookModes] = encodeModes(current)
         }
     }
 
@@ -192,7 +223,7 @@ class SettingsRepository(private val context: Context) {
         context.settingsDataStore.edit { prefs ->
             val current = decodeModes(prefs[key]).toMutableMap()
             current[mapKey] = value
-            prefs[key] = current.entries.joinToString(";") { "${it.key}=${it.value}" }
+            prefs[key] = encodeModes(current)
         }
     }
 
@@ -203,7 +234,7 @@ class SettingsRepository(private val context: Context) {
                 val current = decodeModes(prefs[key]).toMutableMap()
                 val value = current.remove(oldFileName) ?: continue
                 current[newFileName] = value
-                prefs[key] = current.entries.joinToString(";") { "${it.key}=${it.value}" }
+                prefs[key] = encodeModes(current)
             }
         }
     }

--- a/app/src/main/java/com/rrajath/grove/settings/SettingsSerialization.kt
+++ b/app/src/main/java/com/rrajath/grove/settings/SettingsSerialization.kt
@@ -20,7 +20,7 @@ object SettingsSerialization {
     }
 
     fun export(settings: GroveSettings): String =
-        json.encodeToString(SettingsExport.fromSettings(settings))
+        json.encodeToString(SettingsExport.serializer(), SettingsExport.fromSettings(settings))
 
     /**
      * Parse a previously exported document, layering its values over [base] so
@@ -28,7 +28,7 @@ object SettingsSerialization {
      * Throws if [text] isn't valid JSON for this schema.
      */
     fun import(text: String, base: GroveSettings = GroveSettings()): GroveSettings =
-        json.decodeFromString<SettingsExport>(text).applyTo(base)
+        json.decodeFromString(SettingsExport.serializer(), text).applyTo(base)
 }
 
 @Serializable

--- a/app/src/main/java/com/rrajath/grove/settings/SettingsSerialization.kt
+++ b/app/src/main/java/com/rrajath/grove/settings/SettingsSerialization.kt
@@ -1,0 +1,99 @@
+package com.rrajath.grove.settings
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Human-readable JSON backup of the user's preferences (PRD §11 settings).
+ *
+ * Pure Kotlin — no android imports — so the mapping is JVM-testable. Device- and
+ * install-specific state (the SAF vault URI and the onboarding flag) is
+ * deliberately left out: a folder grant can't travel to another device, so an
+ * import keeps whatever folder the current install already points at.
+ */
+object SettingsSerialization {
+
+    private val json = Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    fun export(settings: GroveSettings): String =
+        json.encodeToString(SettingsExport.fromSettings(settings))
+
+    /**
+     * Parse a previously exported document, layering its values over [base] so
+     * the non-portable fields (vault folder, onboarding) survive untouched.
+     * Throws if [text] isn't valid JSON for this schema.
+     */
+    fun import(text: String, base: GroveSettings = GroveSettings()): GroveSettings =
+        json.decodeFromString<SettingsExport>(text).applyTo(base)
+}
+
+@Serializable
+data class SettingsExport(
+    val version: Int = CURRENT_VERSION,
+    val theme: String = ThemePreference.SYSTEM.storageKey,
+    val fontSize: String = FontSizePreference.MEDIUM.storageKey,
+    val defaultNoteOpenMode: String = NoteOpenMode.READ.storageKey,
+    val syncMode: String = SyncMode.ON_OPEN_CLOSE.storageKey,
+    val periodicSyncMinutes: Int = 30,
+    val todoKeywords: String = GroveSettings.DEFAULT_TODO_KEYWORDS,
+    val defaultPriority: String? = null,
+    val addIdToNewNotes: Boolean = false,
+    val addCreatedToNewNotes: Boolean = true,
+    val notebookModes: Map<String, String> = emptyMap(),
+    val notebookIcons: Map<String, String> = emptyMap(),
+    val notebookColors: Map<String, String> = emptyMap(),
+    val captureNotification: Boolean = false,
+    val shareTargetFile: String = GroveSettings.DEFAULT_SHARE_TARGET,
+    val showTagsInOutline: Boolean = true,
+    val showTimestampsInOutline: Boolean = true,
+    val showKeywordsInOutline: Boolean = true,
+) {
+    /** Map back onto [base], using the enums' tolerant `fromStorage` fallbacks. */
+    fun applyTo(base: GroveSettings): GroveSettings = base.copy(
+        theme = ThemePreference.fromStorage(theme),
+        fontSize = FontSizePreference.fromStorage(fontSize),
+        defaultNoteOpenMode = NoteOpenMode.fromStorage(defaultNoteOpenMode),
+        syncMode = SyncMode.fromStorage(syncMode),
+        periodicSyncMinutes = periodicSyncMinutes,
+        todoKeywords = todoKeywords,
+        defaultPriority = defaultPriority?.firstOrNull(),
+        addIdToNewNotes = addIdToNewNotes,
+        addCreatedToNewNotes = addCreatedToNewNotes,
+        notebookModes = notebookModes,
+        notebookIcons = notebookIcons,
+        notebookColors = notebookColors,
+        captureNotification = captureNotification,
+        shareTargetFile = shareTargetFile,
+        showTagsInOutline = showTagsInOutline,
+        showTimestampsInOutline = showTimestampsInOutline,
+        showKeywordsInOutline = showKeywordsInOutline,
+    )
+
+    companion object {
+        const val CURRENT_VERSION = 1
+
+        fun fromSettings(s: GroveSettings): SettingsExport = SettingsExport(
+            theme = s.theme.storageKey,
+            fontSize = s.fontSize.storageKey,
+            defaultNoteOpenMode = s.defaultNoteOpenMode.storageKey,
+            syncMode = s.syncMode.storageKey,
+            periodicSyncMinutes = s.periodicSyncMinutes,
+            todoKeywords = s.todoKeywords,
+            defaultPriority = s.defaultPriority?.toString(),
+            addIdToNewNotes = s.addIdToNewNotes,
+            addCreatedToNewNotes = s.addCreatedToNewNotes,
+            notebookModes = s.notebookModes,
+            notebookIcons = s.notebookIcons,
+            notebookColors = s.notebookColors,
+            captureNotification = s.captureNotification,
+            shareTargetFile = s.shareTargetFile,
+            showTagsInOutline = s.showTagsInOutline,
+            showTimestampsInOutline = s.showTimestampsInOutline,
+            showKeywordsInOutline = s.showKeywordsInOutline,
+        )
+    }
+}

--- a/app/src/main/java/com/rrajath/grove/ui/AppViewModel.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/AppViewModel.kt
@@ -14,6 +14,7 @@ import com.rrajath.grove.settings.GroveSettings
 import com.rrajath.grove.settings.NoteOpenMode
 import com.rrajath.grove.settings.OutlineToggle
 import com.rrajath.grove.settings.SettingsRepository
+import com.rrajath.grove.settings.SettingsSerialization
 import com.rrajath.grove.settings.SyncMode
 import com.rrajath.grove.settings.ThemePreference
 import kotlinx.coroutines.Dispatchers
@@ -131,6 +132,41 @@ class AppViewModel(private val app: GroveApplication) : ViewModel() {
 
     fun setOutlineToggle(toggle: OutlineToggle, enabled: Boolean) =
         viewModelScope.launch { settingsRepository.setOutlineToggle(toggle, enabled) }
+
+    /** Write the current preferences as a JSON document to the user-picked [uri]. */
+    fun exportSettings(uri: android.net.Uri) = viewModelScope.launch {
+        val current = settingsRepository.settings.first()
+        val text = SettingsSerialization.export(current)
+        val ok = withContext(Dispatchers.IO) {
+            runCatching {
+                app.contentResolver.openOutputStream(uri, "wt")?.use {
+                    it.write(text.toByteArray(Charsets.UTF_8))
+                } ?: error("no output stream")
+            }.isSuccess
+        }
+        toast(if (ok) "Settings exported" else "Couldn't write settings file")
+    }
+
+    /** Read a JSON document from [uri] and apply the portable preferences within. */
+    fun importSettings(uri: android.net.Uri) = viewModelScope.launch {
+        val text = withContext(Dispatchers.IO) {
+            runCatching {
+                app.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+            }.getOrNull()
+        }
+        if (text == null) {
+            toast("Couldn't read settings file")
+            return@launch
+        }
+        val current = settingsRepository.settings.first()
+        val imported = runCatching { SettingsSerialization.import(text, current) }.getOrNull()
+        if (imported == null) {
+            toast("Not a valid Grove settings file")
+            return@launch
+        }
+        settingsRepository.applyImported(imported)
+        toast("Settings imported")
+    }
 
     companion object {
         val Factory = object : ViewModelProvider.Factory {

--- a/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
@@ -256,6 +256,8 @@ private fun GroveNavigation(settings: GroveSettings, viewModel: AppViewModel) {
                     onSetCaptureNotification = viewModel::setCaptureNotification,
                     onSetVaultUri = viewModel::setVaultTreeUri,
                     onSetShareTargetFile = viewModel::setShareTargetFile,
+                    onExportSettings = viewModel::exportSettings,
+                    onImportSettings = viewModel::importSettings,
                 )
             }
         }

--- a/app/src/main/java/com/rrajath/grove/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/SettingsScreen.kt
@@ -67,6 +67,8 @@ fun SettingsScreen(
     onSetCaptureNotification: (Boolean) -> Unit,
     onSetVaultUri: (String) -> Unit,
     onSetShareTargetFile: (String) -> Unit,
+    onExportSettings: (android.net.Uri) -> Unit,
+    onImportSettings: (android.net.Uri) -> Unit,
     templatesViewModel: TemplatesViewModel = viewModel(factory = TemplatesViewModel.Factory),
 ) {
     val c = MaterialTheme.grove
@@ -91,6 +93,14 @@ fun SettingsScreen(
             onSetVaultUri(uri.toString())
         }
     }
+
+    val settingsExporter = androidx.activity.compose.rememberLauncherForActivityResult(
+        androidx.activity.result.contract.ActivityResultContracts.CreateDocument("application/json")
+    ) { uri -> if (uri != null) onExportSettings(uri) }
+
+    val settingsImporter = androidx.activity.compose.rememberLauncherForActivityResult(
+        androidx.activity.result.contract.ActivityResultContracts.OpenDocument()
+    ) { uri -> if (uri != null) onImportSettings(uri) }
 
     // Apply pending text edits on leave so back doesn't drop them.
     fun leave() {
@@ -327,6 +337,37 @@ fun SettingsScreen(
                         placeholder = { Text("inbox.org", fontFamily = PlexMono, color = c.ink3) },
                         modifier = Modifier.fillMaxWidth(),
                     )
+                }
+            }
+
+            SectionLabel("BACKUP")
+            SettingsGroup {
+                Column(Modifier.padding(horizontal = 15.dp, vertical = 10.dp)) {
+                    Text(
+                        "Import or export your preferences as a JSON file. The sync"
+                            + " folder isn't included — it stays on this device.",
+                        fontFamily = PlexSans, fontSize = 12.sp, color = c.ink3,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+                }
+                RowDivider()
+                SettingsRow(
+                    label = "Export settings",
+                    onClick = { settingsExporter.launch("grove-settings.json") },
+                ) {
+                    Text("↑", fontFamily = PlexMono, fontSize = 14.sp, color = c.accent)
+                }
+                RowDivider()
+                SettingsRow(
+                    label = "Import settings",
+                    // Providers report .json inconsistently; accept text-ish types too.
+                    onClick = {
+                        settingsImporter.launch(
+                            arrayOf("application/json", "text/plain", "application/octet-stream")
+                        )
+                    },
+                ) {
+                    Text("↓", fontFamily = PlexMono, fontSize = 14.sp, color = c.accent)
                 }
             }
 

--- a/app/src/test/java/com/rrajath/grove/settings/SettingsSerializationTest.kt
+++ b/app/src/test/java/com/rrajath/grove/settings/SettingsSerializationTest.kt
@@ -1,0 +1,103 @@
+package com.rrajath.grove.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SettingsSerializationTest {
+
+    private val sample = GroveSettings(
+        theme = ThemePreference.DARK,
+        fontSize = FontSizePreference.LARGE,
+        defaultNoteOpenMode = NoteOpenMode.EDIT,
+        syncMode = SyncMode.PERIODIC,
+        periodicSyncMinutes = 60,
+        todoKeywords = "TODO NEXT | DONE",
+        defaultPriority = 'B',
+        addIdToNewNotes = true,
+        addCreatedToNewNotes = false,
+        notebookModes = mapOf("work.org" to "edit"),
+        notebookIcons = mapOf("work.org" to "✦"),
+        notebookColors = mapOf("work.org" to "green"),
+        captureNotification = true,
+        shareTargetFile = "capture.org",
+        showTagsInOutline = false,
+        showTimestampsInOutline = false,
+        showKeywordsInOutline = true,
+        // Device-specific fields that must NOT travel with an export.
+        vaultTreeUri = "content://com.android.externalstorage/tree/primary%3Aorg",
+        onboardingDone = true,
+    )
+
+    @Test
+    fun `portable preferences survive an export then import`() {
+        val json = SettingsSerialization.export(sample)
+        // Re-import onto fresh defaults so we can prove every portable field carried.
+        val restored = SettingsSerialization.import(json, GroveSettings())
+
+        assertEquals(sample.theme, restored.theme)
+        assertEquals(sample.fontSize, restored.fontSize)
+        assertEquals(sample.defaultNoteOpenMode, restored.defaultNoteOpenMode)
+        assertEquals(sample.syncMode, restored.syncMode)
+        assertEquals(sample.periodicSyncMinutes, restored.periodicSyncMinutes)
+        assertEquals(sample.todoKeywords, restored.todoKeywords)
+        assertEquals(sample.defaultPriority, restored.defaultPriority)
+        assertEquals(sample.addIdToNewNotes, restored.addIdToNewNotes)
+        assertEquals(sample.addCreatedToNewNotes, restored.addCreatedToNewNotes)
+        assertEquals(sample.notebookModes, restored.notebookModes)
+        assertEquals(sample.notebookIcons, restored.notebookIcons)
+        assertEquals(sample.notebookColors, restored.notebookColors)
+        assertEquals(sample.captureNotification, restored.captureNotification)
+        assertEquals(sample.shareTargetFile, restored.shareTargetFile)
+        assertEquals(sample.showTagsInOutline, restored.showTagsInOutline)
+        assertEquals(sample.showTimestampsInOutline, restored.showTimestampsInOutline)
+        assertEquals(sample.showKeywordsInOutline, restored.showKeywordsInOutline)
+    }
+
+    @Test
+    fun `import preserves the existing vault and onboarding state`() {
+        val json = SettingsSerialization.export(sample)
+        val base = GroveSettings(vaultTreeUri = "content://existing/tree", onboardingDone = false)
+        val restored = SettingsSerialization.import(json, base)
+
+        // The export never carried these, so the base install's values win.
+        assertEquals("content://existing/tree", restored.vaultTreeUri)
+        assertEquals(false, restored.onboardingDone)
+        assertNotEquals(sample.vaultTreeUri, restored.vaultTreeUri)
+    }
+
+    @Test
+    fun `exported document is human-readable json`() {
+        val json = SettingsSerialization.export(sample)
+        assertTrue(json.contains("\"theme\": \"dark\""))
+        assertTrue(json.contains("\"version\": ${SettingsExport.CURRENT_VERSION}"))
+        // Pretty-printed across multiple lines.
+        assertTrue(json.contains("\n"))
+    }
+
+    @Test
+    fun `unknown enum values fall back to defaults on import`() {
+        val json = """{ "theme": "sepia", "fontSize": "huge", "syncMode": "warp" }"""
+        val restored = SettingsSerialization.import(json, GroveSettings())
+
+        assertEquals(ThemePreference.SYSTEM, restored.theme)
+        assertEquals(FontSizePreference.MEDIUM, restored.fontSize)
+        assertEquals(SyncMode.ON_OPEN_CLOSE, restored.syncMode)
+    }
+
+    @Test
+    fun `unknown keys are ignored so newer exports stay importable`() {
+        val json = """{ "theme": "light", "futureField": 42 }"""
+        val restored = SettingsSerialization.import(json, GroveSettings())
+        assertEquals(ThemePreference.LIGHT, restored.theme)
+    }
+
+    @Test
+    fun `malformed json throws`() {
+        assertThrows(Exception::class.java) {
+            SettingsSerialization.import("not json at all", GroveSettings())
+        }
+    }
+}


### PR DESCRIPTION
Add a Backup section to Settings with Export and Import rows. Export
writes the user's preferences to a SAF-picked, pretty-printed JSON file;
import reads such a file and applies the portable settings in one
DataStore transaction.

The device-specific vault folder URI and onboarding flag are
deliberately left out of the export — a folder grant can't travel to
another install — so an import preserves whatever folder the current
device already points at.

Serialization lives in pure Kotlin (SettingsSerialization) and is
covered by a JVM round-trip test, including enum fallback and
unknown-key tolerance for forward compatibility.

https://claude.ai/code/session_014XKD5rqnzGoZ6PcHhvMhjx