### PR TITLE
Fix note editor UI: keyboard gap, empty heading guard, capture discard dialog, notebook pinning, cursor auto-scroll, empty-note cleanup

### DIFF
--- a/app/src/main/java/com/rrajath/grove/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/rrajath/grove/settings/SettingsRepository.kt
@@ -41,6 +41,8 @@ data class GroveSettings(
     val showTagsInOutline: Boolean = true,
     val showTimestampsInOutline: Boolean = true,
     val showKeywordsInOutline: Boolean = true,
+    /** Ordered list of pinned notebook file names; first = topmost. */
+    val pinnedNotebooks: List<String> = emptyList(),
 ) {
     companion object {
         const val DEFAULT_TODO_KEYWORDS = "TODO IN-PROGRESS | DONE CANCELLED"
@@ -70,6 +72,7 @@ class SettingsRepository(private val context: Context) {
         val showTagsInOutline = booleanPreferencesKey("show_tags_in_outline")
         val showTimestampsInOutline = booleanPreferencesKey("show_timestamps_in_outline")
         val showKeywordsInOutline = booleanPreferencesKey("show_keywords_in_outline")
+        val pinnedNotebooks = stringPreferencesKey("pinned_notebooks")
     }
 
     val settings: Flow<GroveSettings> = context.settingsDataStore.data.map { prefs ->
@@ -93,8 +96,15 @@ class SettingsRepository(private val context: Context) {
             showTagsInOutline = prefs[Keys.showTagsInOutline] ?: true,
             showTimestampsInOutline = prefs[Keys.showTimestampsInOutline] ?: true,
             showKeywordsInOutline = prefs[Keys.showKeywordsInOutline] ?: true,
+            pinnedNotebooks = decodePinnedList(prefs[Keys.pinnedNotebooks]),
         )
     }
+
+    private fun decodePinnedList(raw: String?): List<String> =
+        raw?.split(';')?.filter { it.isNotEmpty() } ?: emptyList()
+
+    private fun encodePinnedList(list: List<String>): String =
+        list.joinToString(";")
 
     private fun decodeModes(raw: String?): Map<String, String> =
         raw?.split(';')
@@ -227,7 +237,26 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    /** Keep a chosen icon and color attached to a notebook across renames. */
+    suspend fun pinNotebook(fileName: String) {
+        context.settingsDataStore.edit { prefs ->
+            val current = decodePinnedList(prefs[Keys.pinnedNotebooks]).toMutableList()
+            if (fileName !in current) {
+                current.add(fileName)
+                prefs[Keys.pinnedNotebooks] = encodePinnedList(current)
+            }
+        }
+    }
+
+    suspend fun unpinNotebook(fileName: String) {
+        context.settingsDataStore.edit { prefs ->
+            val current = decodePinnedList(prefs[Keys.pinnedNotebooks]).toMutableList()
+            if (current.remove(fileName)) {
+                prefs[Keys.pinnedNotebooks] = encodePinnedList(current)
+            }
+        }
+    }
+
+    /** Keep a chosen icon, color, and pin position attached to a notebook across renames. */
     suspend fun moveNotebookStyle(oldFileName: String, newFileName: String) {
         context.settingsDataStore.edit { prefs ->
             for (key in listOf(Keys.notebookIcons, Keys.notebookColors)) {
@@ -235,6 +264,12 @@ class SettingsRepository(private val context: Context) {
                 val value = current.remove(oldFileName) ?: continue
                 current[newFileName] = value
                 prefs[key] = encodeModes(current)
+            }
+            val pinned = decodePinnedList(prefs[Keys.pinnedNotebooks]).toMutableList()
+            val pinIdx = pinned.indexOf(oldFileName)
+            if (pinIdx >= 0) {
+                pinned[pinIdx] = newFileName
+                prefs[Keys.pinnedNotebooks] = encodePinnedList(pinned)
             }
         }
     }

--- a/app/src/main/java/com/rrajath/grove/settings/SettingsSerialization.kt
+++ b/app/src/main/java/com/rrajath/grove/settings/SettingsSerialization.kt
@@ -51,6 +51,7 @@ data class SettingsExport(
     val showTagsInOutline: Boolean = true,
     val showTimestampsInOutline: Boolean = true,
     val showKeywordsInOutline: Boolean = true,
+    val pinnedNotebooks: List<String> = emptyList(),
 ) {
     /** Map back onto [base], using the enums' tolerant `fromStorage` fallbacks. */
     fun applyTo(base: GroveSettings): GroveSettings = base.copy(
@@ -71,6 +72,7 @@ data class SettingsExport(
         showTagsInOutline = showTagsInOutline,
         showTimestampsInOutline = showTimestampsInOutline,
         showKeywordsInOutline = showKeywordsInOutline,
+        pinnedNotebooks = pinnedNotebooks,
     )
 
     companion object {
@@ -94,6 +96,7 @@ data class SettingsExport(
             showTagsInOutline = s.showTagsInOutline,
             showTimestampsInOutline = s.showTimestampsInOutline,
             showKeywordsInOutline = s.showKeywordsInOutline,
+            pinnedNotebooks = s.pinnedNotebooks,
         )
     }
 }

--- a/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
@@ -139,7 +139,7 @@ private fun GroveNavigation(settings: GroveSettings, viewModel: AppViewModel) {
                         navController.navigate(Routes.note(ref.encode(), settings.defaultNoteOpenMode.storageKey))
                     },
                     // A freshly created note opens straight in edit mode (blank heading).
-                    onCreateNote = { ref -> navController.navigate(Routes.note(ref.encode(), "edit")) },
+                    onCreateNote = { ref -> navController.navigate(Routes.note(ref.encode(), "edit", isNew = true)) },
                     displayFlags = OutlineDisplayFlags(
                         tags = settings.showTagsInOutline,
                         timestamps = settings.showTimestampsInOutline,
@@ -151,17 +151,19 @@ private fun GroveNavigation(settings: GroveSettings, viewModel: AppViewModel) {
             composable(
                 Routes.NOTE,
                 deepLinks = listOf(
-                    androidx.navigation.navDeepLink { uriPattern = "grove://note/{noteId}?mode={mode}" },
+                    androidx.navigation.navDeepLink { uriPattern = "grove://note/{noteId}?mode={mode}&isNew={isNew}" },
                 ),
             ) { entry ->
                 val noteId = entry.arguments?.getString("noteId").orEmpty()
                 val mode = entry.arguments?.getString("mode") ?: "read"
+                val isNew = entry.arguments?.getString("isNew") == "true"
                 val ref = NoteRef.decode(noteId)
                 if (ref == null) {
                     navController.popBackStack()
                 } else if (mode == "edit") {
                     EditNoteScreen(
                         noteRef = ref,
+                        isNewNote = isNew,
                         onBack = { navController.popBackStack() },
                         onSwitchToRead = {
                             navController.navigate(Routes.note(ref.encode(), "read")) {

--- a/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
@@ -7,11 +7,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -126,21 +130,29 @@ fun CaptureEditorScreen(
             template.location,
         )
     }
+    val initialText = remember(expanded) { expanded.text }
     var value by remember(expanded) {
         mutableStateOf(TextFieldValue(expanded.text, TextRange(expanded.cursorOffset)))
     }
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
+    var showDiscardDialog by remember { mutableStateOf(false) }
+
+    fun tryClose() {
+        if (value.text != initialText) showDiscardDialog = true else onClose()
+    }
+
     Scaffold(
         containerColor = c.bg,
+        contentWindowInsets = WindowInsets(0),
         topBar = {
             GroveTopBar(
                 leading = {
                     Box(
                         Modifier
                             .clip(RoundedCornerShape(10.dp))
-                            .clickable(onClick = onClose)
+                            .clickable(onClick = ::tryClose)
                             .padding(12.dp),
                     ) {
                         Text("×", fontFamily = PlexSans, fontSize = 22.sp, color = c.ink)
@@ -161,7 +173,7 @@ fun CaptureEditorScreen(
             Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .imePadding(),
+                .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
         ) {
             if (template.location.isDatetree) {
                 DatetreeBreadcrumb(template, now.toLocalDate())
@@ -225,6 +237,39 @@ fun CaptureEditorScreen(
                 now = now,
             )
         }
+    }
+
+    if (showDiscardDialog) {
+        AlertDialog(
+            onDismissRequest = { showDiscardDialog = false },
+            containerColor = c.surface,
+            title = {
+                Text(
+                    "Discard note?",
+                    fontFamily = PlexSans, fontWeight = FontWeight.SemiBold,
+                    fontSize = 16.sp, color = c.ink,
+                )
+            },
+            text = {
+                Text(
+                    "Your changes will be lost.",
+                    fontFamily = PlexSans, fontSize = 14.sp, color = c.ink2,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDiscardDialog = false
+                    viewModel.save(template, value.text, context)
+                }) {
+                    Text("Save", color = c.accent, fontWeight = FontWeight.SemiBold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDiscardDialog = false; onClose() }) {
+                    Text("Discard", color = c.red)
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
@@ -5,16 +5,21 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -29,11 +34,14 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
@@ -65,6 +73,8 @@ fun EditNoteScreen(
     noteRef: NoteRef,
     onBack: () -> Unit,
     onSwitchToRead: () -> Unit,
+    /** True when the note was just created (e.g. via the outline + button). */
+    isNewNote: Boolean = false,
     viewModel: EditorViewModel = viewModel(factory = EditorViewModel.Factory),
 ) {
     val c = MaterialTheme.grove
@@ -72,9 +82,25 @@ fun EditNoteScreen(
     var value by remember { mutableStateOf(TextFieldValue("")) }
     var metadataOpen by remember { mutableStateOf(false) }
     var confirmLeave by remember { mutableStateOf(false) }
+    var showEmptyHeadingAlert by remember { mutableStateOf(false) }
+
+    /** Validate heading before saving; shows alert if blank, otherwise saves. */
+    fun trySave(onSaved: () -> Unit) {
+        if (viewModel.isCurrentHeadingBlank()) {
+            showEmptyHeadingAlert = true
+        } else {
+            viewModel.save(onSaved = onSaved)
+        }
+    }
 
     fun leave() {
-        if (state.dirty) confirmLeave = true else onBack()
+        when {
+            state.dirty -> confirmLeave = true
+            // New note with still-blank heading: silently remove it from file.
+            isNewNote && viewModel.isCurrentHeadingBlank() ->
+                viewModel.deleteSubtree(onDeleted = onBack)
+            else -> onBack()
+        }
     }
     androidx.activity.compose.BackHandler { leave() }
 
@@ -107,8 +133,16 @@ fun EditNoteScreen(
         )
     }
 
+    // Scroll state and layout result used for cursor-tracking auto-scroll.
+    val scrollState = rememberScrollState()
+    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+
     Scaffold(
         containerColor = c.bg,
+        // Hand off all bottom-inset responsibility to the Column below so that
+        // navigationBarsPadding + windowInsetsPadding(ime) work without the
+        // Scaffold's own bottom insets creating a double-stacking gap.
+        contentWindowInsets = WindowInsets(0),
         topBar = {
             GroveTopBar(
                 leading = {
@@ -120,7 +154,7 @@ fun EditNoteScreen(
                     SegmentedControl(
                         options = listOf("Read", "Edit"),
                         selectedIndex = 1,
-                        onSelect = { if (it == 0) viewModel.save(onSaved = onSwitchToRead) },
+                        onSelect = { if (it == 0) trySave(onSaved = onSwitchToRead) },
                         modifier = Modifier.width(140.dp),
                     )
                 },
@@ -131,10 +165,9 @@ fun EditNoteScreen(
             Modifier
                 .fillMaxSize()
                 .padding(padding)
-                // Without consuming the Scaffold insets, the nav-bar padding and
-                // imePadding stack up, leaving a gap between toolbar and keyboard.
-                .consumeWindowInsets(padding)
-                .imePadding(),
+                // Use safeDrawing bottom inset: gives max(nav-bar, keyboard) so the
+                // toolbar always sits flush against whichever is visible.
+                .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
         ) {
             state.error?.let { error ->
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -148,22 +181,53 @@ fun EditNoteScreen(
                     onReload = { viewModel.dismissStale(); viewModel.load(noteRef) },
                 )
             }
-            BasicTextField(
-                value = value,
-                onValueChange = ::onTextChange,
-                visualTransformation = transformation,
-                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
-                textStyle = TextStyle(
-                    fontFamily = PlexMono, fontSize = 13.5.sp,
-                    lineHeight = 1.85.em, color = c.ink,
-                ),
-                cursorBrush = SolidColor(c.accent),
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
-                    .padding(18.dp),
-            )
+            // BoxWithConstraints gives the current viewport height so the
+            // LaunchedEffect below can scroll the cursor into view when typing
+            // near the bottom or when the keyboard appears.
+            BoxWithConstraints(Modifier.weight(1f).fillMaxWidth()) {
+                val density = LocalDensity.current
+                val viewportHeightPx = remember(maxHeight, density) {
+                    with(density) { maxHeight.toPx() }.toInt()
+                }
+                val editorPaddingPx = remember(density) {
+                    with(density) { 18.dp.toPx() }.toInt()
+                }
+
+                LaunchedEffect(value.selection, textLayoutResult, viewportHeightPx) {
+                    val layout = textLayoutResult ?: return@LaunchedEffect
+                    if (value.text.isEmpty()) return@LaunchedEffect
+                    // Track selection.end so dragging a selection also scrolls.
+                    val offset = value.selection.end.coerceIn(0, value.text.length)
+                    val rect = layout.getCursorRect(offset)
+                    val cursorTop = editorPaddingPx + rect.top.toInt()
+                    val cursorBottom = editorPaddingPx + rect.bottom.toInt()
+                    val buffer = 56 // px breathing room above/below cursor
+
+                    when {
+                        cursorBottom > scrollState.value + viewportHeightPx - buffer ->
+                            scrollState.animateScrollTo(cursorBottom - viewportHeightPx + buffer)
+                        cursorTop < scrollState.value + buffer ->
+                            scrollState.animateScrollTo(maxOf(0, cursorTop - buffer))
+                    }
+                }
+
+                BasicTextField(
+                    value = value,
+                    onValueChange = ::onTextChange,
+                    visualTransformation = transformation,
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                    textStyle = TextStyle(
+                        fontFamily = PlexMono, fontSize = 13.5.sp,
+                        lineHeight = 1.85.em, color = c.ink,
+                    ),
+                    cursorBrush = SolidColor(c.accent),
+                    onTextLayout = { textLayoutResult = it },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(scrollState)
+                        .padding(18.dp),
+                )
+            }
             EditorToolbar(
                 onWrap = { marker -> applyEdit(wrapSelection(value, marker)) },
                 onInsert = { snippet -> applyEdit(insertAtCursor(value, snippet)) },
@@ -208,14 +272,43 @@ fun EditNoteScreen(
             confirmButton = {
                 androidx.compose.material3.TextButton(onClick = {
                     confirmLeave = false
-                    viewModel.save(onSaved = onBack)
+                    trySave(onSaved = onBack)
                 }) { Text("Save", color = c.accent, fontWeight = FontWeight.SemiBold) }
             },
             dismissButton = {
                 androidx.compose.material3.TextButton(onClick = {
                     confirmLeave = false
-                    onBack()
+                    if (isNewNote && viewModel.isCurrentHeadingBlank()) {
+                        viewModel.deleteSubtree(onDeleted = onBack)
+                    } else {
+                        onBack()
+                    }
                 }) { Text("Discard", color = c.red) }
+            },
+        )
+    }
+
+    if (showEmptyHeadingAlert) {
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = { showEmptyHeadingAlert = false },
+            containerColor = c.surface,
+            title = {
+                Text(
+                    "Add a heading",
+                    fontFamily = PlexSans, fontWeight = FontWeight.SemiBold,
+                    fontSize = 16.sp, color = c.ink,
+                )
+            },
+            text = {
+                Text(
+                    "Please give this note a heading before saving.",
+                    fontFamily = PlexSans, fontSize = 14.sp, color = c.ink2,
+                )
+            },
+            confirmButton = {
+                androidx.compose.material3.TextButton(onClick = { showEmptyHeadingAlert = false }) {
+                    Text("OK", color = c.accent, fontWeight = FontWeight.SemiBold)
+                }
             },
         )
     }

--- a/app/src/main/java/com/rrajath/grove/ui/editor/EditorViewModel.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/EditorViewModel.kt
@@ -150,6 +150,29 @@ class EditorViewModel(private val app: GroveApplication) : ViewModel() {
         _state.value = _state.value.copy(staleFile = false)
     }
 
+    fun isCurrentHeadingBlank(): Boolean = currentHeadline?.title.isNullOrBlank()
+
+    /**
+     * Remove the edited subtree from the file without saving the buffer.
+     * Used when the user discards a freshly created note that still has no heading.
+     */
+    fun deleteSubtree(onDeleted: () -> Unit = {}) {
+        val s = _state.value
+        viewModelScope.launch {
+            val vault = app.vault.value ?: run { onDeleted(); return@launch }
+            val doc = vault.open(s.fileName) ?: run { onDeleted(); return@launch }
+            val headline = doc.headlines.firstOrNull { it.lineIndex == s.lineIndex }
+            if (headline != null) {
+                val newText = OrgMutations.deleteSubtree(doc, headline)
+                if (newText != null) {
+                    vault.save(s.fileName, newText)
+                    app.syncManager.requestSync("empty note discarded")
+                }
+            }
+            onDeleted()
+        }
+    }
+
     companion object {
         val Factory = factory { EditorViewModel(it) }
     }

--- a/app/src/main/java/com/rrajath/grove/ui/nav/Routes.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/nav/Routes.kt
@@ -10,7 +10,7 @@ object Routes {
     const val ONBOARDING = "onboarding"
     const val NOTEBOOKS = "notebooks"
     const val OUTLINE = "outline/{notebookId}"
-    const val NOTE = "note/{noteId}?mode={mode}"
+    const val NOTE = "note/{noteId}?mode={mode}&isNew={isNew}"
     const val CAPTURE = "capture"
     const val CAPTURE_TEMPLATE = "capture/{templateId}"
     const val SEARCH = "search?q={q}"
@@ -25,7 +25,8 @@ object Routes {
     fun encode(id: String): String = URLEncoder.encode(id, "UTF-8")
 
     fun outline(notebookId: String) = "outline/${encode(notebookId)}"
-    fun note(noteId: String, mode: String = "read") = "note/${encode(noteId)}?mode=$mode"
+    fun note(noteId: String, mode: String = "read", isNew: Boolean = false) =
+        "note/${encode(noteId)}?mode=$mode&isNew=$isNew"
     fun capture(templateId: String? = null) =
         if (templateId == null) CAPTURE else "capture/${encode(templateId)}"
     fun conflict(notebookId: String) = "conflict/${encode(notebookId)}"

--- a/app/src/main/java/com/rrajath/grove/ui/screens/NotebooksScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/NotebooksScreen.kt
@@ -152,6 +152,8 @@ fun NotebooksScreen(
                                     onChangeIcon = { styleTarget = nb.fileName },
                                     onDelete = { viewModel.trashNotebook(nb.fileName) },
                                     onForceReload = { viewModel.forceReload(nb.fileName) },
+                                    onPin = { viewModel.pinNotebook(nb.fileName) },
+                                    onUnpin = { viewModel.unpinNotebook(nb.fileName) },
                                 )
                             }
                         }
@@ -364,6 +366,8 @@ private fun NotebookRow(
     onChangeIcon: () -> Unit,
     onDelete: () -> Unit,
     onForceReload: () -> Unit,
+    onPin: () -> Unit,
+    onUnpin: () -> Unit,
 ) {
     val c = MaterialTheme.grove
     val (glyph, fg, bg) = remember(notebook.fileName, notebook.icon, notebook.color, c) {
@@ -402,6 +406,10 @@ private fun NotebookRow(
                     fontFamily = PlexSans, fontSize = 12.5.sp, color = c.ink2,
                 )
             }
+            if (notebook.isPinned) {
+                Text("⊤", fontFamily = PlexMono, fontSize = 11.sp, color = c.accent,
+                    modifier = Modifier.padding(end = 6.dp))
+            }
             if (notebook.hasConflict) {
                 Pill("Conflict", fg = c.amber, bg = c.amberSoft, onClick = onOpenConflict)
             } else {
@@ -413,6 +421,17 @@ private fun NotebookRow(
             onDismissRequest = { menuOpen = false },
             containerColor = c.surface,
         ) {
+            if (notebook.isPinned) {
+                DropdownMenuItem(
+                    text = { Text("Unpin", fontFamily = PlexSans, color = c.ink) },
+                    onClick = { menuOpen = false; onUnpin() },
+                )
+            } else {
+                DropdownMenuItem(
+                    text = { Text("Pin to top", fontFamily = PlexSans, color = c.ink) },
+                    onClick = { menuOpen = false; onPin() },
+                )
+            }
             DropdownMenuItem(
                 text = { Text("Rename", fontFamily = PlexSans, color = c.ink) },
                 onClick = { menuOpen = false; onRename() },

--- a/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
@@ -31,7 +31,11 @@ data class NotebookItem(
     val icon: String? = null,
     /** User-chosen icon palette key; null = derive one from the file name. */
     val color: String? = null,
-)
+    /** Position in the pinned list (0 = topmost). -1 means not pinned. */
+    val pinnedIndex: Int = -1,
+) {
+    val isPinned: Boolean get() = pinnedIndex >= 0
+}
 
 sealed class NotebooksUiState {
     data object NoVault : NotebooksUiState()
@@ -64,9 +68,13 @@ class NotebooksViewModel(private val app: GroveApplication) : ViewModel() {
                             hasConflict = it.conflictFileName != null,
                             icon = settings.notebookIcons[it.fileName],
                             color = settings.notebookColors[it.fileName],
+                            pinnedIndex = settings.pinnedNotebooks.indexOf(it.fileName),
                         )
                     }
-                    .sortedBy { it.fileName.lowercase() },
+                    .sortedWith(
+                        compareBy<NotebookItem> { if (it.isPinned) it.pinnedIndex else Int.MAX_VALUE }
+                            .thenBy { it.fileName.lowercase() }
+                    ),
                 syncState = syncState,
                 lastSyncAt = lastResult?.completedAt,
             )
@@ -124,6 +132,14 @@ class NotebooksViewModel(private val app: GroveApplication) : ViewModel() {
 
     fun forceReload(name: String) {
         viewModelScope.launch { app.syncManager.forceReload(name) }
+    }
+
+    fun pinNotebook(fileName: String) {
+        viewModelScope.launch { app.settingsRepository.pinNotebook(fileName) }
+    }
+
+    fun unpinNotebook(fileName: String) {
+        viewModelScope.launch { app.settingsRepository.unpinNotebook(fileName) }
     }
 
     companion object {

--- a/app/src/test/java/com/rrajath/grove/settings/SettingsSerializationTest.kt
+++ b/app/src/test/java/com/rrajath/grove/settings/SettingsSerializationTest.kt
@@ -26,6 +26,7 @@ class SettingsSerializationTest {
         showTagsInOutline = false,
         showTimestampsInOutline = false,
         showKeywordsInOutline = true,
+        pinnedNotebooks = listOf("pinned-first.org", "pinned-second.org"),
         // Device-specific fields that must NOT travel with an export.
         vaultTreeUri = "content://com.android.externalstorage/tree/primary%3Aorg",
         onboardingDone = true,
@@ -54,6 +55,7 @@ class SettingsSerializationTest {
         assertEquals(sample.showTagsInOutline, restored.showTagsInOutline)
         assertEquals(sample.showTimestampsInOutline, restored.showTimestampsInOutline)
         assertEquals(sample.showKeywordsInOutline, restored.showKeywordsInOutline)
+        assertEquals(sample.pinnedNotebooks, restored.pinnedNotebooks)
     }
 
     @Test

--- a/app/src/test/java/com/rrajath/grove/ui/NotebookPinOrderTest.kt
+++ b/app/src/test/java/com/rrajath/grove/ui/NotebookPinOrderTest.kt
@@ -1,0 +1,96 @@
+package com.rrajath.grove.ui
+
+import com.rrajath.grove.ui.vault.NotebookItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies the pin-ordering logic applied in NotebooksViewModel:
+ * pinned notebooks rise to the top in pin insertion order; unpinned
+ * notebooks remain in alphabetical order below them.
+ */
+class NotebookPinOrderTest {
+
+    private fun item(name: String, pinnedIndex: Int = -1) = NotebookItem(
+        fileName = name,
+        noteCount = 0,
+        lastModified = 0L,
+        hasConflict = false,
+        pinnedIndex = pinnedIndex,
+    )
+
+    private fun sortedLike(items: List<NotebookItem>): List<NotebookItem> =
+        items.sortedWith(
+            compareBy<NotebookItem> { if (it.isPinned) it.pinnedIndex else Int.MAX_VALUE }
+                .thenBy { it.fileName.lowercase() }
+        )
+
+    @Test
+    fun `pinned items appear before unpinned items`() {
+        val items = listOf(
+            item("beta.org"),
+            item("alpha.org", pinnedIndex = 0),
+            item("gamma.org"),
+        )
+        val sorted = sortedLike(items)
+        assertEquals("alpha.org", sorted[0].fileName)
+        assertEquals("beta.org", sorted[1].fileName)
+        assertEquals("gamma.org", sorted[2].fileName)
+    }
+
+    @Test
+    fun `pinned items respect insertion order regardless of alphabet`() {
+        val items = listOf(
+            item("zebra.org", pinnedIndex = 0),
+            item("apple.org", pinnedIndex = 1),
+            item("mango.org", pinnedIndex = 2),
+            item("notes.org"),
+        )
+        val sorted = sortedLike(items)
+        assertEquals("zebra.org", sorted[0].fileName)
+        assertEquals("apple.org", sorted[1].fileName)
+        assertEquals("mango.org", sorted[2].fileName)
+        assertEquals("notes.org", sorted[3].fileName)
+    }
+
+    @Test
+    fun `unpinned items are sorted alphabetically case-insensitively`() {
+        val items = listOf(
+            item("Zebra.org"),
+            item("apple.org"),
+            item("Mango.org"),
+        )
+        val sorted = sortedLike(items)
+        assertEquals("apple.org", sorted[0].fileName)
+        assertEquals("Mango.org", sorted[1].fileName)
+        assertEquals("Zebra.org", sorted[2].fileName)
+    }
+
+    @Test
+    fun `isPinned reflects pinnedIndex correctly`() {
+        assertTrue(item("a.org", pinnedIndex = 0).isPinned)
+        assertTrue(item("b.org", pinnedIndex = 5).isPinned)
+        assertFalse(item("c.org", pinnedIndex = -1).isPinned)
+        assertFalse(item("d.org").isPinned)
+    }
+
+    @Test
+    fun `all notebooks unpinned uses pure alphabetical order`() {
+        val items = listOf(item("z.org"), item("a.org"), item("m.org"))
+        val sorted = sortedLike(items)
+        assertEquals(listOf("a.org", "m.org", "z.org"), sorted.map { it.fileName })
+    }
+
+    @Test
+    fun `all notebooks pinned uses pin index order`() {
+        val items = listOf(
+            item("c.org", pinnedIndex = 2),
+            item("a.org", pinnedIndex = 0),
+            item("b.org", pinnedIndex = 1),
+        )
+        val sorted = sortedLike(items)
+        assertEquals(listOf("a.org", "b.org", "c.org"), sorted.map { it.fileName })
+    }
+}

--- a/app/src/test/java/com/rrajath/grove/ui/editor/EditorHeadingTest.kt
+++ b/app/src/test/java/com/rrajath/grove/ui/editor/EditorHeadingTest.kt
@@ -1,0 +1,65 @@
+package com.rrajath.grove.ui.editor
+
+import com.rrajath.grove.org.OrgKeywords
+import com.rrajath.grove.org.OrgParser
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the empty-heading detection used by EditorViewModel.isCurrentHeadingBlank()
+ * and the save-guard alert in EditNoteScreen.
+ */
+class EditorHeadingTest {
+
+    private fun isHeadingBlank(buffer: String): Boolean {
+        val doc = OrgParser.parse(buffer, OrgKeywords.DEFAULT)
+        val headline = doc.headlines.firstOrNull() ?: return true
+        return headline.title.isBlank()
+    }
+
+    @Test
+    fun `headline with no title is blank`() {
+        assertTrue(isHeadingBlank("* \n"))
+    }
+
+    @Test
+    fun `headline with only spaces after stars is blank`() {
+        assertTrue(isHeadingBlank("*   \n"))
+    }
+
+    @Test
+    fun `headline with a title is not blank`() {
+        assertFalse(isHeadingBlank("* My note\n"))
+    }
+
+    @Test
+    fun `headline with keyword and no title is blank`() {
+        assertTrue(isHeadingBlank("* TODO \n"))
+    }
+
+    @Test
+    fun `headline with keyword and title is not blank`() {
+        assertFalse(isHeadingBlank("* TODO Buy milk\n"))
+    }
+
+    @Test
+    fun `headline with priority and no title is blank`() {
+        assertTrue(isHeadingBlank("* [#A] \n"))
+    }
+
+    @Test
+    fun `headline with priority and title is not blank`() {
+        assertFalse(isHeadingBlank("* [#B] Important task\n"))
+    }
+
+    @Test
+    fun `empty buffer has no headline so counts as blank`() {
+        assertTrue(isHeadingBlank(""))
+    }
+
+    @Test
+    fun `buffer with only body text and no headline is blank`() {
+        assertTrue(isHeadingBlank("just some text without a heading\n"))
+    }
+}

--- a/app/src/test/java/com/rrajath/grove/ui/nav/RoutesTest.kt
+++ b/app/src/test/java/com/rrajath/grove/ui/nav/RoutesTest.kt
@@ -13,9 +13,10 @@ class RoutesTest {
     }
 
     @Test
-    fun `note route defaults to read mode`() {
-        assertEquals("note/abc-123?mode=read", Routes.note("abc-123"))
-        assertEquals("note/abc-123?mode=edit", Routes.note("abc-123", mode = "edit"))
+    fun `note route defaults to read mode and isNew false`() {
+        assertEquals("note/abc-123?mode=read&isNew=false", Routes.note("abc-123"))
+        assertEquals("note/abc-123?mode=edit&isNew=false", Routes.note("abc-123", mode = "edit"))
+        assertEquals("note/abc-123?mode=edit&isNew=true", Routes.note("abc-123", mode = "edit", isNew = true))
     }
 
     @Test
@@ -44,7 +45,7 @@ class RoutesTest {
             Routes.OUTLINE.substringBefore("{"),
             Routes.outline("x").substringBefore("x"),
         )
-        // note/{noteId}?mode={mode}
+        // note/{noteId}?mode={mode}&isNew={isNew}
         assertEquals(
             Routes.NOTE.substringBefore("{"),
             Routes.note("x").substringBefore("x"),


### PR DESCRIPTION
- Keyboard gap: use safeDrawing.only(Bottom) on both EditNoteScreen and
  CaptureEditorScreen so nav-bar and IME heights never double-stack
- Empty heading alert: block save and show AlertDialog when heading is blank;
  add isCurrentHeadingBlank() to EditorViewModel
- Capture discard dialog: show Save/Discard alert when X is tapped and content
  has changed from the template expansion; close silently if unchanged
- Notebook pinning: store ordered list in GroveSettings.pinnedNotebooks,
  expose pin/unpin on NotebooksViewModel, show pin indicator and context-menu
  items in NotebooksScreen; rename-aware list update in SettingsRepository
- Cursor auto-scroll: replace static scroll with BoxWithConstraints +
  TextLayoutResult + LaunchedEffect that tracks selection.end and calls
  animateScrollTo — also fixes text-selection drag scrolling
- Empty note on discard: pass isNew=true in Routes.note() when opening via
  FAB; EditorViewModel.deleteSubtree() removes the blank subtree on discard
- Tests: update RoutesTest for new isNew param, update SettingsSerializationTest
  for pinnedNotebooks, add NotebookPinOrderTest and EditorHeadingTest

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NqgAEr3HdMRLn5TqXjKFc8