### PR TITLE
Fix four app bugs: sync race, pin icon, clipboard toast, heading caps

### DIFF
--- a/app/src/main/java/com/rrajath/grove/org/LineEditing.kt
+++ b/app/src/main/java/com/rrajath/grove/org/LineEditing.kt
@@ -77,6 +77,28 @@ object LineEditing {
         )
     }
 
+    private val HEADING_FIRST_CHAR = Regex("""^\*+ [a-z]$""")
+
+    /**
+     * Auto-capitalize the first letter typed into an org heading. Returns null
+     * when no capitalization is needed (not a heading line, char already uppercase,
+     * or cursor not right after the first content character).
+     *
+     * Call this after [continueListOnEnter] in the text-change handler, passing
+     * the old text (before the edit) and the new text + cursor from the IME.
+     */
+    fun capitalizeHeadingOnType(oldText: String, newText: String, cursor: Int): TextEdit? {
+        if (newText.length != oldText.length + 1) return null
+        if (cursor < 1 || cursor > newText.length) return null
+        val newChar = newText[cursor - 1]
+        if (!newChar.isLetter() || newChar.isUpperCase()) return null
+        val lineStart = newText.lastIndexOf('\n', cursor - 2) + 1
+        val lineUpToCursor = newText.substring(lineStart, cursor)
+        if (!HEADING_FIRST_CHAR.matches(lineUpToCursor)) return null
+        val capitalized = newText.substring(0, cursor - 1) + newChar.uppercaseChar() + newText.substring(cursor)
+        return TextEdit(capitalized, cursor)
+    }
+
     /**
      * Toolbar `*` button: on an empty heading line (`* `, `** `…) demote it by
      * one star; anywhere else start a new heading on the next line.

--- a/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
@@ -111,9 +111,14 @@ fun CaptureEditorScreen(
 
     val context = remember(template, promptValues) {
         val share = app.pendingShare.value
+        // Only read the clipboard when the template actually uses %clipboard.
+        // Android 13+ shows a system toast on every clipboard read, so reading
+        // unconditionally would confuse users whose templates don't need it.
+        val clipboardText =
+            if (template.template.contains("%clipboard")) clipboard.getText()?.text ?: "" else ""
         CaptureContext(
             now = now,
-            clipboard = clipboard.getText()?.text ?: "",
+            clipboard = clipboardText,
             sharedText = share?.text ?: "",
             sharedUrl = share?.url ?: "",
             promptValues = promptValues ?: emptyMap(),
@@ -192,9 +197,15 @@ fun CaptureEditorScreen(
                         val continued = LineEditing.continueListOnEnter(
                             value.text, newValue.text, newValue.selection.start,
                         )
-                        value =
+                        val effective =
                             if (continued != null) TextFieldValue(continued.text, TextRange(continued.cursor))
                             else newValue
+                        val capitalized = LineEditing.capitalizeHeadingOnType(
+                            value.text, effective.text, effective.selection.start,
+                        )
+                        value =
+                            if (capitalized != null) TextFieldValue(capitalized.text, TextRange(capitalized.cursor))
+                            else effective
                     },
                     keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
                     textStyle = TextStyle(
@@ -463,6 +474,7 @@ private fun PromptDialog(
                         value = values[prompt].orEmpty(),
                         onValueChange = { values = values + (prompt to it) },
                         singleLine = true,
+                        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
                         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
                     )
                 }

--- a/app/src/main/java/com/rrajath/grove/ui/capture/CaptureViewModel.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/capture/CaptureViewModel.kt
@@ -12,6 +12,8 @@ import com.rrajath.grove.capture.TemplatesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.time.LocalDate
@@ -38,11 +40,6 @@ class CaptureViewModel(private val app: GroveApplication) : ViewModel() {
      * if it doesn't exist yet.
      */
     fun save(template: CaptureTemplate, entryText: String, context: CaptureContext) {
-        val vault = app.vault.value
-        if (vault == null) {
-            _saveState.value = SaveState.Failed("No sync folder configured")
-            return
-        }
         if (entryText.isBlank()) {
             _saveState.value = SaveState.Failed("Nothing to save")
             return
@@ -50,6 +47,14 @@ class CaptureViewModel(private val app: GroveApplication) : ViewModel() {
         _saveState.value = SaveState.Saving
         viewModelScope.launch {
             try {
+                val settings = app.settingsRepository.settings.first()
+                if (settings.vaultTreeUri == null) {
+                    _saveState.value = SaveState.Failed("No sync folder configured")
+                    return@launch
+                }
+                // On a cold start (e.g. launched via app shortcut) the vault may
+                // still be initializing even though a folder is configured; await it.
+                val vault = app.vault.filterNotNull().first()
                 if (!vault.open(template.targetFile).let { it != null }) {
                     vault.createNotebook(template.targetFile)
                 }

--- a/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
@@ -127,9 +127,15 @@ fun EditNoteScreen(
         val continued = LineEditing.continueListOnEnter(
             value.text, newValue.text, newValue.selection.start,
         )
-        applyEdit(
+        val effective =
             if (continued != null) TextFieldValue(continued.text, TextRange(continued.cursor))
             else newValue
+        val capitalized = LineEditing.capitalizeHeadingOnType(
+            value.text, effective.text, effective.selection.start,
+        )
+        applyEdit(
+            if (capitalized != null) TextFieldValue(capitalized.text, TextRange(capitalized.cursor))
+            else effective
         )
     }
 

--- a/app/src/main/java/com/rrajath/grove/ui/screens/NotebooksScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/NotebooksScreen.kt
@@ -25,11 +25,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.ui.res.painterResource
+import com.rrajath.grove.R
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -407,8 +410,12 @@ private fun NotebookRow(
                 )
             }
             if (notebook.isPinned) {
-                Text("⊤", fontFamily = PlexMono, fontSize = 11.sp, color = c.accent,
-                    modifier = Modifier.padding(end = 6.dp))
+                Icon(
+                    painter = painterResource(R.drawable.ic_pin),
+                    contentDescription = null,
+                    tint = c.accent,
+                    modifier = Modifier.padding(end = 6.dp).size(14.dp),
+                )
             }
             if (notebook.hasConflict) {
                 Pill("Conflict", fg = c.amber, bg = c.amberSoft, onClick = onOpenConflict)

--- a/app/src/main/res/drawable/ic_pin.xml
+++ b/app/src/main/res/drawable/ic_pin.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M16,9V4h1c0.55,0,1,-0.45,1,-1s-0.45,-1,-1,-1H7c-0.55,0,-1,0.45,-1,1s0.45,1,1,1h1v5c0,1.66,-1.34,3,-3,3v2h5.97v7l1,1,1,-1v-7H19v-2C17.34,12,16,10.66,16,9z" />
+</vector>


### PR DESCRIPTION
## Summary

- **Sync race on cold start**: `CaptureViewModel.save()` was failing with "No sync folder configured" when launched via app shortcut because the vault `StateFlow` hadn't finished initializing yet. Now checks `vaultTreeUri` in settings first, then awaits the vault via `filterNotNull().first()` — matching the pattern in `consumeSharedContent()`.
- **Pin icon**: Replaced the `⊤` (mathematical top symbol) on the notebooks screen with a proper pushpin vector drawable (`ic_pin.xml`, Material Design push_pin path) rendered via the `Icon` composable with accent color tinting.
- **Spurious clipboard toast**: Android 13+ shows a system toast on every clipboard read. The capture editor was calling `clipboard.getText()` unconditionally even for templates that never use `%clipboard`. Fixed to only read clipboard when `template.template.contains("%clipboard")`.
- **Heading auto-capitalization**: `KeyboardCapitalization.Sentences` doesn't fire after org heading markers (`* `). Added `LineEditing.capitalizeHeadingOnType()` which detects when the first character is typed into a heading line and capitalizes it programmatically. Called from both `EditNoteScreen.onTextChange` and `CaptureEditorScreen.onValueChange`. Also added `KeyboardCapitalization.Sentences` to the `PromptDialog` title field used by Quick Note and capture template prompts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCm1egS4M2V4itesMtH7pX)_