### PR TITLE
Revert double-tap cursor positioning, extend scroll jump buttons

### DIFF
--- a/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
@@ -159,8 +159,6 @@ private fun GroveNavigation(settings: GroveSettings, viewModel: AppViewModel) {
                 val noteId = entry.arguments?.getString("noteId").orEmpty()
                 val mode = entry.arguments?.getString("mode") ?: "read"
                 val isNew = entry.arguments?.getString("isNew") == "true"
-                val cursorArg = entry.arguments?.getString("cursor")?.toIntOrNull()
-                val initialCursor = cursorArg?.takeIf { it >= 0 }
                 val ref = NoteRef.decode(noteId)
                 if (ref == null) {
                     navController.popBackStack()
@@ -168,7 +166,6 @@ private fun GroveNavigation(settings: GroveSettings, viewModel: AppViewModel) {
                     EditNoteScreen(
                         noteRef = ref,
                         isNewNote = isNew,
-                        initialCursor = initialCursor,
                         onBack = { navController.popBackStack() },
                         onSwitchToRead = {
                             navController.navigate(Routes.note(ref.encode(), "read")) {
@@ -181,8 +178,8 @@ private fun GroveNavigation(settings: GroveSettings, viewModel: AppViewModel) {
                         noteRef = ref,
                         onBack = { navController.popBackStack() },
                         onOpenNote = { target -> navController.navigate(Routes.note(target.encode())) },
-                        onEdit = { tappedOffset ->
-                            navController.navigate(Routes.note(ref.encode(), "edit", cursor = tappedOffset)) {
+                        onEdit = {
+                            navController.navigate(Routes.note(ref.encode(), "edit")) {
                                 popUpTo(Routes.NOTE) { inclusive = true }
                             }
                         },

--- a/app/src/main/java/com/rrajath/grove/ui/components/AutoScroll.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/components/AutoScroll.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.isActive
 
 /**
@@ -65,9 +64,7 @@ private suspend fun ScrollState.nudge(urgency: Float) {
  * appeared and the user grabs it for a fresh touch, Compose renders that
  * handle in its own [androidx.compose.ui.window.Popup] — a separate Android
  * window — so its drag events never reach this (or any) modifier on the
- * underlying content; this modifier can't help there. For BasicTextField,
- * [chaseSelectionEdge] fixes that case too, by watching the selection's value
- * instead of raw touches. See that function's kdoc.
+ * underlying content; this modifier can't help there.
  */
 fun Modifier.autoScrollWhileDragging(scrollState: ScrollState, edgeSize: Dp = 56.dp): Modifier = composed {
     val density = LocalDensity.current
@@ -100,40 +97,4 @@ fun Modifier.autoScrollWhileDragging(scrollState: ScrollState, edgeSize: Dp = 56
                 pointerY = null
             }
         }
-}
-
-/**
- * Continuously auto-scrolls [scrollState] to follow a text selection's active
- * edge as it nears the top/bottom of the viewport — including while the user
- * is dragging a selection *handle*, whose touch events [autoScrollWhileDragging]
- * can't see (they land in a separate Popup window; see its kdoc).
- *
- * Unlike raw pointer tracking, this is driven purely by the selection's
- * current value, which BasicTextField/SelectionContainer keep updating live
- * as the user drags — including handle drags — regardless of which window
- * the touch itself is delivered to. [edgeYProvider] should return the current
- * viewport-local Y (already adjusted for [scrollState]'s current offset — see
- * call site) of whichever selection edge is more "urgently" past a viewport
- * edge, or null when there's no active/measurable selection.
- *
- * Practical note: like standard Android text selection, this needs the
- * selection value to keep changing (i.e. the finger to keep moving, even
- * slightly) to keep scrolling — a perfectly motionless finger parked past the
- * edge won't continue to scroll on its own, matching native `EditText`
- * behavior (which is likewise driven by `ACTION_MOVE`, not a timer).
- */
-suspend fun chaseSelectionEdge(
-    scrollState: ScrollState,
-    edgePx: Float,
-    viewportHeightPx: () -> Int,
-    edgeYProvider: () -> Float?,
-) {
-    while (coroutineContext.isActive) {
-        val h = viewportHeightPx()
-        val y = edgeYProvider()
-        if (y != null && h > 0) {
-            scrollState.nudge(edgeUrgency(y, h, edgePx))
-        }
-        withFrameNanos {}
-    }
 }

--- a/app/src/main/java/com/rrajath/grove/ui/components/DoubleTapGesture.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/components/DoubleTapGesture.kt
@@ -9,11 +9,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextLayoutResult
 
 /**
- * Detects a double-tap on rendered org text and reports the tapped *rendered*
- * character offset (i.e. an index into the [AnnotatedString][androidx.compose.ui.text.AnnotatedString]
- * actually shown, not the raw org markup) — callers map that back to a raw
- * file offset themselves, since the mapping differs per block type (see
- * ReadNoteScreen).
+ * Detects a double-tap on rendered org text and invokes [onDoubleTap].
  *
  * Unlike a plain `detectTapGestures(onDoubleTap = ...)`, this never consumes
  * the *first* tap of a pair: it only watches (at [PointerEventPass.Final], the
@@ -33,7 +29,7 @@ fun Modifier.doubleTapToEdit(
     layoutResult: () -> TextLayoutResult?,
     links: List<InlineLink> = emptyList(),
     enabled: Boolean = true,
-    onDoubleTap: (Int) -> Unit,
+    onDoubleTap: () -> Unit,
 ): Modifier {
     if (!enabled) return this
     return this.pointerInput(Unit) {
@@ -85,7 +81,7 @@ fun Modifier.doubleTapToEdit(
                     change.consume()
                     if (!change.pressed) break
                 }
-                onDoubleTap(charOffset)
+                onDoubleTap()
             }
         }
     }

--- a/app/src/main/java/com/rrajath/grove/ui/components/ScrollJumpButtons.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/components/ScrollJumpButtons.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -15,7 +16,12 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,17 +29,25 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.rrajath.grove.ui.theme.grove
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
  * A vertically-stacked pair of small round jump buttons (scroll-to-top above
  * scroll-to-bottom) anchored to the bottom-right of the screen. Operates on
- * the caller's own [ScrollState] — no new scroll state is created.
+ * the caller's own [ScrollState] or [LazyListState] — no new scroll state is
+ * created.
  *
- * The pair is hidden entirely when [scrollState] has no scrollable overflow
- * (content fits on screen). Each button additionally hides itself once
- * already at that edge (top button disappears at the top, bottom button
- * disappears at the bottom).
+ * Visibility behavior:
+ * - The pair is hidden entirely when the underlying content has no
+ *   scrollable overflow (content fits on screen).
+ * - The pair appears as soon as any scroll activity happens (a position
+ *   change), and disappears again after 3 seconds of scroll inactivity.
+ *   Scrolling again at any point makes it reappear immediately and resets
+ *   the idle timer.
+ * - Each button additionally hides itself once already at that edge (the
+ *   top button disappears at the top, the bottom button disappears at the
+ *   bottom), even while the pair is otherwise visible.
  *
  * Callers should place this inside a `Box` and align it with
  * `Modifier.align(Alignment.BottomEnd)`, adding extra bottom padding to
@@ -44,27 +58,99 @@ fun ScrollJumpButtons(
     scrollState: ScrollState,
     modifier: Modifier = Modifier,
 ) {
-    // No overflow: nothing to jump to, hide the whole pair.
-    if (scrollState.maxValue <= 0) return
-
-    val scope = rememberCoroutineScope()
+    val hasOverflow = scrollState.maxValue > 0
+    val visible = rememberScrollActivityVisible(scrollState.value)
     val atTop = scrollState.value <= 0
     val atBottom = scrollState.value >= scrollState.maxValue
+    val scope = rememberCoroutineScope()
+
+    ScrollJumpButtonsRow(
+        visible = visible && hasOverflow,
+        showTop = !atTop,
+        showBottom = !atBottom,
+        onScrollToTop = { scope.launch { scrollState.animateScrollTo(0) } },
+        onScrollToBottom = { scope.launch { scrollState.animateScrollTo(scrollState.maxValue) } },
+        modifier = modifier,
+    )
+}
+
+/** [LazyListState] overload — see [ScrollJumpButtons] for behavior details. */
+@Composable
+fun ScrollJumpButtons(
+    listState: LazyListState,
+    modifier: Modifier = Modifier,
+) {
+    val hasOverflow = listState.canScrollForward || listState.canScrollBackward
+    val positionKey = listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+    val visible = rememberScrollActivityVisible(positionKey)
+    val atTop = !listState.canScrollBackward
+    val atBottom = !listState.canScrollForward
+    val scope = rememberCoroutineScope()
+
+    ScrollJumpButtonsRow(
+        visible = visible && hasOverflow,
+        showTop = !atTop,
+        showBottom = !atBottom,
+        onScrollToTop = { scope.launch { listState.animateScrollToItem(0) } },
+        onScrollToBottom = {
+            scope.launch {
+                val lastIndex = listState.layoutInfo.totalItemsCount - 1
+                if (lastIndex >= 0) listState.animateScrollToItem(lastIndex)
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+/**
+ * Tracks whether jump buttons should be visible based on scroll activity: becomes
+ * true the moment [positionKey] changes (i.e. the user scrolled), then flips back
+ * to false after 3 seconds without further changes. Does not show on first
+ * composition — only once actual scroll movement is observed.
+ */
+@Composable
+private fun <T> rememberScrollActivityVisible(positionKey: T): Boolean {
+    var visible by remember { mutableStateOf(false) }
+    var previous by remember { mutableStateOf<T?>(null) }
+
+    LaunchedEffect(positionKey) {
+        val prior = previous
+        if (prior != null && prior != positionKey) {
+            visible = true
+        }
+        previous = positionKey
+        delay(3000)
+        visible = false
+    }
+
+    return visible
+}
+
+@Composable
+private fun ScrollJumpButtonsRow(
+    visible: Boolean,
+    showTop: Boolean,
+    showBottom: Boolean,
+    onScrollToTop: () -> Unit,
+    onScrollToBottom: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!visible) return
 
     Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-        if (!atTop) {
+        if (showTop) {
             ScrollJumpButton(
                 icon = Icons.Default.KeyboardArrowUp,
                 contentDescription = "Scroll to top",
-                onClick = { scope.launch { scrollState.animateScrollTo(0) } },
+                onClick = onScrollToTop,
             )
             Spacer(Modifier.height(8.dp))
         }
-        if (!atBottom) {
+        if (showBottom) {
             ScrollJumpButton(
                 icon = Icons.Default.KeyboardArrowDown,
                 contentDescription = "Scroll to bottom",
-                onClick = { scope.launch { scrollState.animateScrollTo(scrollState.maxValue) } },
+                onClick = onScrollToBottom,
             )
         }
     }

--- a/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
@@ -43,8 +42,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -56,7 +53,6 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rrajath.grove.org.LineEditing
 import com.rrajath.grove.ui.components.GroveTopBar
-import com.rrajath.grove.ui.components.chaseSelectionEdge
 import com.rrajath.grove.ui.components.ScrollJumpButtons
 import com.rrajath.grove.ui.components.SegmentedControl
 import com.rrajath.grove.ui.screens.IconGlyph
@@ -79,10 +75,6 @@ fun EditNoteScreen(
     onSwitchToRead: () -> Unit,
     /** True when the note was just created (e.g. via the outline + button). */
     isNewNote: Boolean = false,
-    /** Raw-buffer char offset to place the cursor at on open — e.g. from a
-     * double-tap in read mode. Null falls back to the default (end of the
-     * heading line). */
-    initialCursor: Int? = null,
     viewModel: EditorViewModel = viewModel(factory = EditorViewModel.Factory),
 ) {
     val c = MaterialTheme.grove
@@ -119,10 +111,9 @@ fun EditNoteScreen(
     LaunchedEffect(noteRef) { viewModel.load(noteRef) }
     LaunchedEffect(state.loading) {
         if (!state.loading && state.error == null) {
-            val cursor = initialCursor?.coerceIn(0, state.buffer.length)
-                ?: state.buffer.length.coerceAtMost(
-                    state.buffer.indexOf('\n').let { if (it == -1) state.buffer.length else it },
-                )
+            val cursor = state.buffer.length.coerceAtMost(
+                state.buffer.indexOf('\n').let { if (it == -1) state.buffer.length else it },
+            )
             value = TextFieldValue(state.buffer, TextRange(cursor))
         }
     }
@@ -169,9 +160,7 @@ fun EditNoteScreen(
         )
     }
 
-    // Scroll state and layout result used for cursor-tracking auto-scroll.
     val scrollState = rememberScrollState()
-    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
 
     Scaffold(
         containerColor = c.bg,
@@ -235,47 +224,7 @@ fun EditNoteScreen(
                     onReload = { viewModel.dismissStale(); viewModel.load(noteRef) },
                 )
             }
-            // BoxWithConstraints gives the current viewport height so the
-            // LaunchedEffect below can scroll the cursor/selection into view
-            // both while typing and while dragging to select.
-            BoxWithConstraints(Modifier.weight(1f).fillMaxWidth()) {
-                val density = LocalDensity.current
-                val viewportHeightPx = remember(maxHeight, density) {
-                    with(density) { maxHeight.toPx() }.toInt()
-                }
-                val editorPaddingPx = remember(density) {
-                    with(density) { 18.dp.toPx() }.toInt()
-                }
-                val edgePx = remember(density) { with(density) { 56.dp.toPx() } }
-
-                // Selection-driven auto-scroll: continuously nudges the caret (or
-                // whichever selection edge is being dragged) back into view as it
-                // nears the top/bottom edge. Driven by TextFieldValue.selection
-                // rather than raw touch, this is what makes it work even while
-                // dragging a selection *handle* — handles render in their own
-                // Popup window, so their touches never reach a pointerInput on
-                // this content (see AutoScroll.kt's kdoc) but they do keep
-                // updating `value.selection` live, which is all this needs.
-                LaunchedEffect(scrollState) {
-                    chaseSelectionEdge(
-                        scrollState = scrollState,
-                        edgePx = edgePx,
-                        viewportHeightPx = { viewportHeightPx },
-                    ) {
-                        val layout = textLayoutResult
-                        if (layout == null || value.text.isEmpty()) return@chaseSelectionEdge null
-                        fun yOf(offset: Int): Float =
-                            editorPaddingPx + layout.getCursorRect(offset.coerceIn(0, value.text.length))
-                                .center.y - scrollState.value
-                        fun overflow(y: Float): Float =
-                            maxOf(edgePx - y, y - (viewportHeightPx - edgePx), 0f)
-
-                        val startY = yOf(value.selection.start)
-                        val endY = yOf(value.selection.end)
-                        if (overflow(startY) >= overflow(endY)) startY else endY
-                    }
-                }
-
+            Box(Modifier.weight(1f).fillMaxWidth()) {
                 BasicTextField(
                     value = value,
                     onValueChange = ::onTextChange,
@@ -286,7 +235,6 @@ fun EditNoteScreen(
                         lineHeight = 1.85.em, color = c.ink,
                     ),
                     cursorBrush = SolidColor(c.accent),
-                    onTextLayout = { textLayoutResult = it },
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(scrollState)

--- a/app/src/main/java/com/rrajath/grove/ui/nav/Routes.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/nav/Routes.kt
@@ -10,7 +10,7 @@ object Routes {
     const val ONBOARDING = "onboarding"
     const val NOTEBOOKS = "notebooks"
     const val OUTLINE = "outline/{notebookId}"
-    const val NOTE = "note/{noteId}?mode={mode}&isNew={isNew}&cursor={cursor}"
+    const val NOTE = "note/{noteId}?mode={mode}&isNew={isNew}"
     const val CAPTURE = "capture"
     const val CAPTURE_TEMPLATE = "capture/{templateId}"
     const val SEARCH = "search?q={q}"
@@ -25,14 +25,8 @@ object Routes {
     fun encode(id: String): String = URLEncoder.encode(id, "UTF-8")
 
     fun outline(notebookId: String) = "outline/${encode(notebookId)}"
-    /**
-     * [cursor] is the raw-file character offset to place the edit-mode cursor
-     * at when opening straight into edit mode (e.g. from a double-tap in read
-     * mode) — null means "no specific position" (editor falls back to its
-     * default of the end of the heading line).
-     */
-    fun note(noteId: String, mode: String = "read", isNew: Boolean = false, cursor: Int? = null) =
-        "note/${encode(noteId)}?mode=$mode&isNew=$isNew&cursor=${cursor ?: -1}"
+    fun note(noteId: String, mode: String = "read", isNew: Boolean = false) =
+        "note/${encode(noteId)}?mode=$mode&isNew=$isNew"
     fun capture(templateId: String? = null) =
         if (templateId == null) CAPTURE else "capture/${encode(templateId)}"
     fun conflict(notebookId: String) = "conflict/${encode(notebookId)}"

--- a/app/src/main/java/com/rrajath/grove/ui/screens/NotebooksScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/NotebooksScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
@@ -57,6 +58,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rrajath.grove.sync.SyncState
 import com.rrajath.grove.ui.components.GroveTopBar
 import com.rrajath.grove.ui.components.Pill
+import com.rrajath.grove.ui.components.ScrollJumpButtons
 import com.rrajath.grove.ui.theme.GroveColors
 import com.rrajath.grove.ui.theme.PlexMono
 import com.rrajath.grove.ui.theme.PlexSans
@@ -152,20 +154,32 @@ fun NotebooksScreen(
                     if (s.notebooks.isEmpty()) {
                         CenterMessage("✦", "No .org files here yet", "Capture a note or create a notebook with ＋")
                     } else {
-                        LazyColumn(Modifier.fillMaxSize().testTag("notebooks_list")) {
-                            items(s.notebooks, key = { it.fileName }) { nb ->
-                                NotebookRow(
-                                    notebook = nb,
-                                    onClick = { onOpenNotebook(nb.fileName) },
-                                    onOpenConflict = { onOpenConflict(nb.fileName) },
-                                    onRename = { renameTarget = nb.fileName },
-                                    onChangeIcon = { styleTarget = nb.fileName },
-                                    onDelete = { viewModel.trashNotebook(nb.fileName) },
-                                    onForceReload = { viewModel.forceReload(nb.fileName) },
-                                    onPin = { viewModel.pinNotebook(nb.fileName) },
-                                    onUnpin = { viewModel.unpinNotebook(nb.fileName) },
-                                )
+                        val listState = rememberLazyListState()
+                        Box(Modifier.fillMaxSize()) {
+                            LazyColumn(
+                                state = listState,
+                                modifier = Modifier.fillMaxSize().testTag("notebooks_list"),
+                            ) {
+                                items(s.notebooks, key = { it.fileName }) { nb ->
+                                    NotebookRow(
+                                        notebook = nb,
+                                        onClick = { onOpenNotebook(nb.fileName) },
+                                        onOpenConflict = { onOpenConflict(nb.fileName) },
+                                        onRename = { renameTarget = nb.fileName },
+                                        onChangeIcon = { styleTarget = nb.fileName },
+                                        onDelete = { viewModel.trashNotebook(nb.fileName) },
+                                        onForceReload = { viewModel.forceReload(nb.fileName) },
+                                        onPin = { viewModel.pinNotebook(nb.fileName) },
+                                        onUnpin = { viewModel.unpinNotebook(nb.fileName) },
+                                    )
+                                }
                             }
+                            ScrollJumpButtons(
+                                listState = listState,
+                                modifier = Modifier
+                                    .align(Alignment.BottomEnd)
+                                    .padding(bottom = 86.dp, end = 16.dp),
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/rrajath/grove/ui/screens/OutlineScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/OutlineScreen.kt
@@ -44,6 +44,7 @@ import com.rrajath.grove.org.OrgHeadline
 import com.rrajath.grove.settings.OutlineToggle
 import com.rrajath.grove.ui.components.GroveTopBar
 import com.rrajath.grove.ui.components.Pill
+import com.rrajath.grove.ui.components.ScrollJumpButtons
 import com.rrajath.grove.ui.components.annotateOrgInline
 import com.rrajath.grove.ui.theme.PlexMono
 import com.rrajath.grove.ui.theme.PlexSans
@@ -244,6 +245,7 @@ fun OutlineScreen(
                             )
                         }
                     }
+                    Box(Modifier.fillMaxSize()) {
                     LazyColumn(
                         state = listState,
                         modifier = Modifier
@@ -291,6 +293,15 @@ fun OutlineScreen(
                                 ),
                             )
                         }
+                    }
+                    ScrollJumpButtons(
+                        listState = listState,
+                        // Stacked above the FAB (54.dp + its own padding) so the two
+                        // never overlap.
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(bottom = 86.dp, end = 16.dp),
+                    )
                     }
                 }
             }

--- a/app/src/main/java/com/rrajath/grove/ui/screens/ReadNoteScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/ReadNoteScreen.kt
@@ -58,7 +58,6 @@ import com.rrajath.grove.ui.components.GroveTopBar
 import com.rrajath.grove.ui.components.Pill
 import com.rrajath.grove.ui.components.SegmentedControl
 import com.rrajath.grove.ui.components.annotateOrgInline
-import com.rrajath.grove.ui.components.autoScrollWhileDragging
 import com.rrajath.grove.ui.components.doubleTapToEdit
 import com.rrajath.grove.ui.components.linkPressHandler
 import com.rrajath.grove.ui.components.orgInlineLinks
@@ -81,10 +80,8 @@ fun ReadNoteScreen(
     noteRef: NoteRef,
     onBack: () -> Unit,
     onOpenNote: (NoteRef) -> Unit,
-    /** Double-tap anywhere switches to edit mode; the raw-file char offset
-     * nearest the tap is passed when it could be determined (see
-     * [rawOffsetForTitleTap] / [rawOffsetForParagraphTap] etc.), else null. */
-    onEdit: (Int?) -> Unit,
+    /** Double-tap anywhere switches to edit mode. */
+    onEdit: () -> Unit,
     viewModel: DocumentViewModel = viewModel(factory = DocumentViewModel.Factory),
 ) {
     val c = MaterialTheme.grove
@@ -113,7 +110,7 @@ fun ReadNoteScreen(
                     SegmentedControl(
                         options = listOf("Read", "Edit"),
                         selectedIndex = 0,
-                        onSelect = { if (it == 1) onEdit(null) },
+                        onSelect = { if (it == 1) onEdit() },
                         modifier = Modifier.width(140.dp),
                     )
                 },
@@ -147,17 +144,15 @@ fun ReadNoteScreen(
                                 modifier = Modifier
                                     .fillMaxSize()
                                     // Fallback: double-tap on blank space (not over any
-                                    // rendered text run) still switches to edit mode, just
-                                    // without a mapped cursor position. Taps that land on
-                                    // actual text are handled per-run below (doubleTapToEdit
-                                    // on each OrgText/line), which both wins the gesture race
-                                    // against SelectionContainer's own double-tap-select-word
-                                    // and can compute a real offset — so in practice this
-                                    // outer catch-all only ever fires for empty margins.
+                                    // rendered text run) still switches to edit mode. Taps
+                                    // that land on actual text are handled per-run below
+                                    // (doubleTapToEdit on each OrgText/line), which wins the
+                                    // gesture race against SelectionContainer's own
+                                    // double-tap-select-word — so in practice this outer
+                                    // catch-all only ever fires for empty margins.
                                     .pointerInput(Unit) {
-                                        detectTapGestures(onDoubleTap = { onEdit(null) })
+                                        detectTapGestures(onDoubleTap = { onEdit() })
                                     }
-                                    .autoScrollWhileDragging(scrollState)
                                     .verticalScroll(scrollState)
                                     .padding(horizontal = 24.dp),
                                 onOpenNote = onOpenNote,
@@ -184,7 +179,7 @@ private fun NoteContent(
     headline: OrgHeadline,
     fileName: String,
     onOpenNote: (NoteRef) -> Unit,
-    onEditAt: (Int?) -> Unit,
+    onEditAt: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val c = MaterialTheme.grove
@@ -229,9 +224,7 @@ private fun NoteContent(
             }
             OrgText(
                 headline.title, onOpenLink = openLink, onLinkLongPress = onLinkLongPress,
-                onDoubleTapAt = { renderedOffset ->
-                    onEditAt(doc.rawOffsetForTitleTap(headline, renderedOffset))
-                },
+                onDoubleTapAt = onEditAt,
                 style = TextStyle(
                     fontFamily = PlexSerif, fontWeight = FontWeight.SemiBold,
                     fontSize = 25.sp, color = c.ink, lineHeight = 1.3.em,
@@ -269,9 +262,7 @@ private fun NoteContent(
                     }
                     OrgText(
                         child.title, onOpenLink = openLink, onLinkLongPress = onLinkLongPress,
-                        onDoubleTapAt = { renderedOffset ->
-                            onEditAt(doc.rawOffsetForTitleTap(child, renderedOffset))
-                        },
+                        onDoubleTapAt = onEditAt,
                         style = TextStyle(
                             fontFamily = PlexSerif, fontWeight = FontWeight.SemiBold,
                             fontSize = when (rel) {
@@ -317,11 +308,9 @@ private fun OrgText(
     style: TextStyle = TextStyle.Default,
     maxLines: Int = Int.MAX_VALUE,
     overflow: TextOverflow = TextOverflow.Clip,
-    /** Double-tap anywhere in this run switches to edit mode; reports the
-     * tapped offset into the *rendered* [text] (not raw org markup) so
-     * callers can map it back to a raw-file offset. Word-selection via
-     * long-press, and link taps, are unaffected — see [doubleTapToEdit]. */
-    onDoubleTapAt: ((Int) -> Unit)? = null,
+    /** Double-tap anywhere in this run switches to edit mode. Word-selection
+     * via long-press, and link taps, are unaffected — see [doubleTapToEdit]. */
+    onDoubleTapAt: (() -> Unit)? = null,
 ) {
     val c = MaterialTheme.grove
     val annotated = remember(text, c) { annotateOrgInline(text, c, onOpenLink) }
@@ -346,7 +335,7 @@ private fun OrgText(
                 layoutResult = { layout },
                 links = links,
                 enabled = onDoubleTapAt != null,
-                onDoubleTap = { offset -> onDoubleTapAt?.invoke(offset) },
+                onDoubleTap = { onDoubleTapAt?.invoke() },
             )
             .linkPressHandler(
                 links = links,
@@ -404,7 +393,7 @@ private fun BodyBlocks(
     fileName: String,
     onOpenNote: (NoteRef) -> Unit,
     onLinkLongPress: (String, Offset, LayoutCoordinates) -> Unit,
-    onEditAt: (Int?) -> Unit,
+    onEditAt: () -> Unit,
 ) {
     val c = MaterialTheme.grove
     val context = LocalContext.current
@@ -417,9 +406,7 @@ private fun BodyBlocks(
                 OrgText(
                     block.lines.joinToString(" ") { it.trim() },
                     onOpenLink = openTarget, onLinkLongPress = onLinkLongPress,
-                    onDoubleTapAt = { renderedOffset ->
-                        onEditAt(doc.rawOffsetForParagraphTap(headline, block, renderedOffset))
-                    },
+                    onDoubleTapAt = onEditAt,
                     style = TextStyle(fontFamily = PlexSerif, fontSize = 16.sp, lineHeight = 1.65.em, color = c.ink),
                 )
                 Spacer(Modifier.height(12.dp))
@@ -442,9 +429,7 @@ private fun BodyBlocks(
                             OrgText(
                                 item.text,
                                 onOpenLink = openTarget, onLinkLongPress = onLinkLongPress,
-                                onDoubleTapAt = { renderedOffset ->
-                                    onEditAt(doc.rawOffsetForListItemTap(headline, item, renderedOffset))
-                                },
+                                onDoubleTapAt = onEditAt,
                                 style = TextStyle(
                                     fontFamily = PlexSerif, fontSize = 16.sp,
                                     lineHeight = 1.55.em, color = c.ink,
@@ -464,12 +449,10 @@ private fun BodyBlocks(
                         .background(c.surface2)
                         .padding(12.dp),
                 ) {
-                    block.lines.forEachIndexed { i, line ->
+                    block.lines.forEach { line ->
                         PlainTappableLine(
                             line, fontFamily = PlexMono, fontSize = 13.sp, color = c.ink,
-                            onDoubleTapAt = { renderedOffset ->
-                                onEditAt(doc.offsetAt(headline.bodyStart + block.startLine + i, renderedOffset))
-                            },
+                            onDoubleTapAt = onEditAt,
                         )
                     }
                 }
@@ -485,12 +468,10 @@ private fun BodyBlocks(
                         .background(c.surface)
                         .padding(10.dp),
                 ) {
-                    block.lines.forEachIndexed { i, line ->
+                    block.lines.forEach { line ->
                         PlainTappableLine(
                             line, fontFamily = PlexMono, fontSize = 12.5.sp, color = c.ink,
-                            onDoubleTapAt = { renderedOffset ->
-                                onEditAt(doc.offsetAt(headline.bodyStart + block.startLine + i, renderedOffset))
-                            },
+                            onDoubleTapAt = onEditAt,
                         )
                     }
                     Text(
@@ -513,7 +494,7 @@ private fun PlainTappableLine(
     fontFamily: androidx.compose.ui.text.font.FontFamily,
     fontSize: androidx.compose.ui.unit.TextUnit,
     color: Color,
-    onDoubleTapAt: (Int) -> Unit,
+    onDoubleTapAt: () -> Unit,
 ) {
     var layout by remember { mutableStateOf<TextLayoutResult?>(null) }
     Text(
@@ -525,61 +506,6 @@ private fun PlainTappableLine(
             onDoubleTap = onDoubleTapAt,
         ),
     )
-}
-
-/** Raw-file char offset for line [lineIndex], clamped to that line's length. */
-private fun OrgDocument.offsetAt(lineIndex: Int, column: Int): Int {
-    if (lineIndex !in lines.indices) return text.length
-    var offset = 0
-    for (i in 0 until lineIndex) offset += lines[i].length + 1
-    return (offset + column.coerceIn(0, lines[lineIndex].length))
-}
-
-/** Maps a tap in a rendered headline title back to that title's raw line. */
-private fun OrgDocument.rawOffsetForTitleTap(headline: OrgHeadline, renderedOffset: Int): Int {
-    val raw = lines.getOrNull(headline.lineIndex) ?: return offsetAt(headline.lineIndex, renderedOffset)
-    val titleStart = raw.indexOf(headline.title)
-    val column = if (titleStart >= 0) titleStart + renderedOffset.coerceIn(0, headline.title.length) else renderedOffset
-    return offsetAt(headline.lineIndex, column)
-}
-
-/**
- * Maps a tap in a rendered paragraph (raw lines joined with " ", each
- * trimmed) back to a raw line + column. Approximate: inline markup stripped
- * by [annotateOrgInline] means the rendered offset isn't byte-identical to
- * the raw one, but it lands on the right line and very close to the right
- * column in the common case (plain prose with little/no inline markup).
- */
-private fun OrgDocument.rawOffsetForParagraphTap(
-    headline: OrgHeadline,
-    block: OrgBlock.Paragraph,
-    renderedOffset: Int,
-): Int {
-    var remaining = renderedOffset
-    block.lines.forEachIndexed { relIndex, raw ->
-        val trimmed = raw.trim()
-        if (remaining <= trimmed.length) {
-            val leadingWs = raw.length - raw.trimStart().length
-            return offsetAt(headline.bodyStart + block.startLine + relIndex, leadingWs + remaining)
-        }
-        remaining -= trimmed.length + 1 // + the joining space
-    }
-    val lastRel = block.lines.lastIndex.coerceAtLeast(0)
-    val lastLine = block.lines.getOrNull(lastRel).orEmpty()
-    return offsetAt(headline.bodyStart + block.startLine + lastRel, lastLine.length)
-}
-
-/** Maps a tap in a rendered list item's text back to its raw line + column. */
-private fun OrgDocument.rawOffsetForListItemTap(
-    headline: OrgHeadline,
-    item: OrgBlock.ListItem,
-    renderedOffset: Int,
-): Int {
-    val absoluteLine = headline.bodyStart + item.line
-    val raw = lines.getOrNull(absoluteLine) ?: return offsetAt(absoluteLine, renderedOffset)
-    val textStart = raw.indexOf(item.text)
-    val column = if (textStart >= 0) textStart + renderedOffset.coerceIn(0, item.text.length) else renderedOffset
-    return offsetAt(absoluteLine, column)
 }
 
 /** Resolve an org link target: internal id/custom-id jumps to the note, else opens externally. */

--- a/app/src/main/java/com/rrajath/grove/ui/screens/SyncLogScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/SyncLogScreen.kt
@@ -1,12 +1,14 @@
 package com.rrajath.grove.ui.screens
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -14,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
@@ -22,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rrajath.grove.ui.components.GroveTopBar
+import com.rrajath.grove.ui.components.ScrollJumpButtons
 import com.rrajath.grove.ui.theme.PlexMono
 import com.rrajath.grove.ui.theme.PlexSans
 import com.rrajath.grove.ui.theme.grove
@@ -57,10 +61,12 @@ fun SyncLogScreen(
             )
         },
     ) { padding ->
+        val listState = rememberLazyListState()
+        Box(Modifier.fillMaxSize().padding(padding)) {
         LazyColumn(
-            Modifier
+            state = listState,
+            modifier = Modifier
                 .fillMaxSize()
-                .padding(padding)
                 .padding(horizontal = 16.dp),
         ) {
             items(entries, key = { it.id }) { entry ->
@@ -93,6 +99,13 @@ fun SyncLogScreen(
                     )
                 }
             }
+        }
+        ScrollJumpButtons(
+            listState = listState,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+        )
         }
     }
 }

--- a/app/src/main/java/com/rrajath/grove/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/search/SearchScreen.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.AlertDialog
@@ -46,6 +48,7 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rrajath.grove.ui.components.Pill
+import com.rrajath.grove.ui.components.ScrollJumpButtons
 import com.rrajath.grove.ui.screens.IconGlyph
 import com.rrajath.grove.ui.theme.PlexMono
 import com.rrajath.grove.ui.theme.PlexSans
@@ -69,6 +72,7 @@ fun SearchScreen(
     var advancedOpen by remember { mutableStateOf(false) }
     var saveDialogOpen by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
+    val listState = rememberLazyListState()
 
     LaunchedEffect(initialQuery) {
         if (!initialQuery.isNullOrBlank()) viewModel.submit(initialQuery)
@@ -152,10 +156,18 @@ fun SearchScreen(
                 })
             }
 
-            when {
-                state.query.isBlank() -> HistoryList(state.history, onTap = viewModel::submit)
-                state.agenda != null -> AgendaList(state.agenda!!, onOpenNote)
-                else -> ResultsList(state.results, onOpenNote)
+            Box(Modifier.weight(1f).fillMaxWidth()) {
+                when {
+                    state.query.isBlank() -> HistoryList(listState, state.history, onTap = viewModel::submit)
+                    state.agenda != null -> AgendaList(listState, state.agenda!!, onOpenNote)
+                    else -> ResultsList(listState, state.results, onOpenNote)
+                }
+                ScrollJumpButtons(
+                    listState = listState,
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(16.dp),
+                )
             }
         }
     }
@@ -233,9 +245,9 @@ private fun OpChip(label: String, onTap: (String) -> Unit) {
 }
 
 @Composable
-private fun HistoryList(history: List<String>, onTap: (String) -> Unit) {
+private fun HistoryList(listState: LazyListState, history: List<String>, onTap: (String) -> Unit) {
     val c = MaterialTheme.grove
-    LazyColumn(Modifier.fillMaxSize().padding(horizontal = 14.dp)) {
+    LazyColumn(state = listState, modifier = Modifier.fillMaxSize().padding(horizontal = 14.dp)) {
         if (history.isNotEmpty()) {
             items(history) { entry ->
                 Row(
@@ -256,8 +268,8 @@ private fun HistoryList(history: List<String>, onTap: (String) -> Unit) {
 }
 
 @Composable
-private fun ResultsList(results: List<SearchResult>, onOpenNote: (NoteRef) -> Unit) {
-    LazyColumn(Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 4.dp)) {
+private fun ResultsList(listState: LazyListState, results: List<SearchResult>, onOpenNote: (NoteRef) -> Unit) {
+    LazyColumn(state = listState, modifier = Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 4.dp)) {
         items(results, key = { "${it.fileName}@${it.lineIndex}" }) { result ->
             ResultRow(result, onOpenNote)
             HorizontalDivider(
@@ -269,10 +281,10 @@ private fun ResultsList(results: List<SearchResult>, onOpenNote: (NoteRef) -> Un
 }
 
 @Composable
-private fun AgendaList(agenda: List<AgendaDay>, onOpenNote: (NoteRef) -> Unit) {
+private fun AgendaList(listState: LazyListState, agenda: List<AgendaDay>, onOpenNote: (NoteRef) -> Unit) {
     val c = MaterialTheme.grove
     val formatter = remember { DateTimeFormatter.ofPattern("EEEE, MMM d", Locale.ENGLISH) }
-    LazyColumn(Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 4.dp)) {
+    LazyColumn(state = listState, modifier = Modifier.fillMaxSize().padding(horizontal = 14.dp, vertical = 4.dp)) {
         agenda.forEach { day ->
             item(key = day.date.toString()) {
                 Text(

--- a/app/src/test/java/com/rrajath/grove/ui/nav/RoutesTest.kt
+++ b/app/src/test/java/com/rrajath/grove/ui/nav/RoutesTest.kt
@@ -13,16 +13,12 @@ class RoutesTest {
     }
 
     @Test
-    fun `note route defaults to read mode, isNew false, no cursor`() {
-        assertEquals("note/abc-123?mode=read&isNew=false&cursor=-1", Routes.note("abc-123"))
-        assertEquals("note/abc-123?mode=edit&isNew=false&cursor=-1", Routes.note("abc-123", mode = "edit"))
+    fun `note route defaults to read mode, isNew false`() {
+        assertEquals("note/abc-123?mode=read&isNew=false", Routes.note("abc-123"))
+        assertEquals("note/abc-123?mode=edit&isNew=false", Routes.note("abc-123", mode = "edit"))
         assertEquals(
-            "note/abc-123?mode=edit&isNew=true&cursor=-1",
+            "note/abc-123?mode=edit&isNew=true",
             Routes.note("abc-123", mode = "edit", isNew = true),
-        )
-        assertEquals(
-            "note/abc-123?mode=edit&isNew=false&cursor=42",
-            Routes.note("abc-123", mode = "edit", cursor = 42),
         )
     }
 


### PR DESCRIPTION
Remove the broken read-mode double-tap cursor positioning (initialCursor, chaseSelectionEdge, offset mapping) so scrolling and text selection use stock Compose behavior; double-tap still switches to edit mode.

Add ScrollJumpButtons to notebooks, outline, search, and sync log screens with new visibility behavior: appear on scroll, hide after 3s idle.