### PR TITLE
Fix Sentry release version mismatch and remove capture template label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,18 @@ jobs:
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest
 
+      # Computed once here and reused for the GitHub Release tag/title below.
+      # build.gradle.kts derives versionName and the Sentry release
+      # (io.sentry.release manifest placeholder) from the same git commit
+      # count independently, so all three agree without needing to thread a
+      # value through the build step — the Sentry Android Gradle plugin has
+      # no env-var hook to receive one.
+      - name: Compute version
+        run: |
+          set -euo pipefail
+          VERSION="$(./gradlew -q printVersionName | tail -n1)"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
       - name: Decode release keystore
         if: env.HAS_SIGNING == 'true'
         env:
@@ -81,16 +93,17 @@ jobs:
           if-no-files-found: error
 
       # Publish a GitHub Release with both APKs on every push to the default
-      # branch. The tag is the git-derived versionName (v1.0.<commit-count>),
-      # which is unique and monotonic per commit. Re-runs of the same commit
-      # re-upload the assets instead of failing on an existing tag.
+      # branch. The tag is "v$VERSION" — the same VERSION computed once above,
+      # and the same format build.gradle.kts uses for the Sentry release — so
+      # GitHub and Sentry always agree on what a given build is called.
+      # Re-runs of the same commit re-upload the assets instead of failing on
+      # an existing tag.
       - name: Publish GitHub Release
         if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          VERSION="$(./gradlew -q printVersionName | tail -n1)"
           TAG="v$VERSION"
           # The release APK is app-release.apk when signed, app-release-unsigned.apk otherwise.
           ASSETS=$(ls app/build/outputs/apk/debug/*.apk app/build/outputs/apk/release/*.apk)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,15 @@ fun gitOutput(args: List<String>): String? {
 val gitCommitCount = gitOutput(listOf("rev-list", "--count", "HEAD"))?.toIntOrNull() ?: 1
 val semanticVersion = "$versionMajor.$versionMinor.$gitCommitCount"
 
+// The release string the Sentry SDK reports at runtime (crash/event "release"
+// tag). Kept identical to the GitHub Release tag (see
+// .github/workflows/build.yml, which tags "v$semanticVersion") so a Sentry
+// issue's release always resolves to a real, findable GitHub Release. The
+// Sentry Android Gradle plugin has no env-var hook for this (unlike its JS/
+// fastlane counterparts) — the only override point is this manifest
+// placeholder, consumed by the io.sentry.release meta-data below.
+val sentryRelease = "v$semanticVersion"
+
 // Release signing comes from the environment (CI secrets). We validate the
 // keystore and alias up front so a missing or misconfigured secret degrades to
 // an unsigned release build instead of failing packaging — and a local
@@ -83,6 +92,7 @@ android {
         targetSdk = 36
         versionCode = gitCommitCount
         versionName = semanticVersion
+        manifestPlaceholders["sentryRelease"] = sentryRelease
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,7 +85,7 @@
     <meta-data android:name="io.sentry.dsn" android:value="https://22613e1316854dcc4634e34bd7964521@o4504759805476864.ingest.us.sentry.io/4511700837138432" />
 
     <!-- set up releases -->
-    <meta-data android:name="io.sentry.release" android:value="io.example@1.1.0" />
+    <meta-data android:name="io.sentry.release" android:value="${sentryRelease}" />
     <!-- set up sentry session tracking -->
     <meta-data android:name="io.sentry.session-tracking.timeout-interval-millis" android:value="60000" />
     <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->

--- a/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
@@ -396,8 +396,6 @@ private fun DatetreeBreadcrumb(template: CaptureTemplate, today: LocalDate) {
             .padding(horizontal = 18.dp, vertical = 11.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text("inserts under", fontFamily = PlexMono, fontSize = 11.5.sp, color = c.ink3, maxLines = 1)
-        Spacer(Modifier.width(7.dp))
         // The breadcrumb shares the row with the trailing pill; only the file
         // name may shrink (ellipsized), so nothing ever wraps vertically.
         Row(Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
Wire the Sentry runtime release string to the same git-derived version used for the GitHub Release tag, replacing a hardcoded wizard placeholder that caused Sentry to show a stale, unrelated version. Also drop the "inserts under" label from the capture template top bar.