### PR TITLE
Support dashed tags, last-used refile location, and fix timestamp/content line break

### DIFF
--- a/app/src/main/java/com/rrajath/grove/org/OrgParser.kt
+++ b/app/src/main/java/com/rrajath/grove/org/OrgParser.kt
@@ -155,7 +155,7 @@ class OrgDocument(
 object OrgParser {
 
     private val HEADLINE = Regex("""^(\*+)\s+(.*)$""")
-    private val TAGS_AT_END = Regex("""\s+(:[A-Za-z0-9_@#%]+(?::[A-Za-z0-9_@#%]+)*:)\s*$""")
+    private val TAGS_AT_END = Regex("""\s+(:[A-Za-z0-9_@#%-]+(?::[A-Za-z0-9_@#%-]+)*:)\s*$""")
     private val PRIORITY = Regex("""^\[#([A-Za-z])\]\s*""")
     private val FILETAGS = Regex("""^#\+(?i:FILETAGS):\s*(.*)$""")
     private val PROPERTY_LINE = Regex("""^\s*:([^:\s]+):\s*(.*)$""")

--- a/app/src/main/java/com/rrajath/grove/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/rrajath/grove/settings/SettingsRepository.kt
@@ -51,6 +51,10 @@ data class GroveSettings(
     val showPropertyDrawers: Boolean = true,
     /** Notebook list label: raw file name, or the `#+TITLE:` cached in the index. */
     val notebookDisplayNameMode: NotebookDisplayNameMode = NotebookDisplayNameMode.FILENAME,
+    /** Destination file of the most recent successful refile; null until one has happened. */
+    val lastRefileFile: String? = null,
+    /** '/'-separated heading path within [lastRefileFile]; empty = top level. */
+    val lastRefileHeadingPath: String = "",
 ) {
     companion object {
         const val DEFAULT_TODO_KEYWORDS = "TODO IN-PROGRESS | DONE CANCELLED"
@@ -85,6 +89,8 @@ class SettingsRepository(private val context: Context) {
         val showHeaderTags = booleanPreferencesKey("show_header_tags")
         val showPropertyDrawers = booleanPreferencesKey("show_property_drawers")
         val notebookDisplayNameMode = stringPreferencesKey("notebook_display_name_mode")
+        val lastRefileFile = stringPreferencesKey("last_refile_file")
+        val lastRefileHeadingPath = stringPreferencesKey("last_refile_heading_path")
     }
 
     val settings: Flow<GroveSettings> = context.settingsDataStore.data.map { prefs ->
@@ -113,6 +119,8 @@ class SettingsRepository(private val context: Context) {
             showHeaderTags = prefs[Keys.showHeaderTags] ?: true,
             showPropertyDrawers = prefs[Keys.showPropertyDrawers] ?: true,
             notebookDisplayNameMode = NotebookDisplayNameMode.fromStorage(prefs[Keys.notebookDisplayNameMode]),
+            lastRefileFile = prefs[Keys.lastRefileFile],
+            lastRefileHeadingPath = prefs[Keys.lastRefileHeadingPath] ?: "",
         )
     }
 
@@ -248,6 +256,13 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun setNotebookDisplayNameMode(mode: NotebookDisplayNameMode) {
         context.settingsDataStore.edit { it[Keys.notebookDisplayNameMode] = mode.storageKey }
+    }
+
+    suspend fun setLastRefileTarget(fileName: String, headingPath: List<String>) {
+        context.settingsDataStore.edit { prefs ->
+            prefs[Keys.lastRefileFile] = fileName
+            prefs[Keys.lastRefileHeadingPath] = headingPath.joinToString("/")
+        }
     }
 
     suspend fun setNotebookIcon(fileName: String, glyph: String) {

--- a/app/src/main/java/com/rrajath/grove/ui/editor/OrgVisualTransformation.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/OrgVisualTransformation.kt
@@ -159,7 +159,7 @@ class OrgVisualTransformation(
 
     companion object {
         private val HEADLINE = Regex("""^(\*+)\s+(.*)$""")
-        private val TAGS_AT_END = Regex("""\s+(:[A-Za-z0-9_@#%]+(?::[A-Za-z0-9_@#%]+)*:)\s*$""")
+        private val TAGS_AT_END = Regex("""\s+(:[A-Za-z0-9_@#%-]+(?::[A-Za-z0-9_@#%-]+)*:)\s*$""")
         private val TIMESTAMP = Regex("""[<\[][^>\]]*[>\]]""")
         private val PLANNING_KW = Regex("""(SCHEDULED|DEADLINE|CLOSED):""")
         private val PROPERTY = Regex("""^\s*:([^:\s]+):\s*(.*)$""")

--- a/app/src/main/java/com/rrajath/grove/ui/screens/OutlineScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/OutlineScreen.kt
@@ -442,6 +442,7 @@ fun OutlineScreen(
                         onCancel = viewModel::refileCancel,
                         onConfirm = viewModel::refileConfirm,
                         onArchive = viewModel::refileToArchive,
+                        onPickLastUsed = viewModel::refileToLastUsed,
                     )
                 }
             }

--- a/app/src/main/java/com/rrajath/grove/ui/screens/ReadNoteScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/ReadNoteScreen.kt
@@ -60,6 +60,7 @@ import com.rrajath.grove.org.BlockParser
 import com.rrajath.grove.org.OrgBlock
 import com.rrajath.grove.org.OrgDocument
 import com.rrajath.grove.org.OrgHeadline
+import com.rrajath.grove.org.OrgTimestamp
 import com.rrajath.grove.ui.components.CollapsibleKvSection
 import com.rrajath.grove.ui.components.FavoriteStar
 import com.rrajath.grove.ui.components.GroveTopBar
@@ -493,12 +494,31 @@ private fun BodyBlocks(
     blocks.forEach { block ->
         when (block) {
             is OrgBlock.Paragraph -> {
-                OrgText(
-                    block.lines.joinToString(" ") { it.trim() },
-                    onOpenLink = openTarget, onLinkLongPress = onLinkLongPress,
-                    onDoubleTapAt = onEditAt,
-                    style = TextStyle(fontFamily = PlexSerif, fontSize = 16.sp, lineHeight = 1.65.em, color = c.ink),
-                )
+                // A standalone timestamp line (e.g. a journal entry's inactive
+                // timestamp) starts its own line rather than running into the
+                // text that follows it with just a joining space.
+                val firstLine = block.lines.first().trim()
+                if (block.lines.size > 1 && isStandaloneTimestamp(firstLine)) {
+                    OrgText(
+                        firstLine,
+                        onOpenLink = openTarget, onLinkLongPress = onLinkLongPress,
+                        onDoubleTapAt = onEditAt,
+                        style = TextStyle(fontFamily = PlexSerif, fontSize = 16.sp, lineHeight = 1.65.em, color = c.ink),
+                    )
+                    OrgText(
+                        block.lines.drop(1).joinToString(" ") { it.trim() },
+                        onOpenLink = openTarget, onLinkLongPress = onLinkLongPress,
+                        onDoubleTapAt = onEditAt,
+                        style = TextStyle(fontFamily = PlexSerif, fontSize = 16.sp, lineHeight = 1.65.em, color = c.ink),
+                    )
+                } else {
+                    OrgText(
+                        block.lines.joinToString(" ") { it.trim() },
+                        onOpenLink = openTarget, onLinkLongPress = onLinkLongPress,
+                        onDoubleTapAt = onEditAt,
+                        style = TextStyle(fontFamily = PlexSerif, fontSize = 16.sp, lineHeight = 1.65.em, color = c.ink),
+                    )
+                }
                 Spacer(Modifier.height(12.dp))
             }
 
@@ -574,6 +594,12 @@ private fun BodyBlocks(
             }
         }
     }
+}
+
+/** True when [line] (already trimmed) is nothing but a single org timestamp. */
+private fun isStandaloneTimestamp(line: String): Boolean {
+    val (_, range) = OrgTimestamp.parseWithRange(line) ?: return false
+    return range.first == 0 && range.last == line.length - 1
 }
 
 /** A single plain (non-org-markup) line — code/table content — that maps a

--- a/app/src/main/java/com/rrajath/grove/ui/screens/RefileSheet.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/RefileSheet.kt
@@ -58,6 +58,7 @@ fun RefileSheet(
     onCancel: () -> Unit,
     onConfirm: () -> Unit,
     onArchive: () -> Unit,
+    onPickLastUsed: () -> Unit,
 ) {
     val c = MaterialTheme.grove
     val doc = state.pickedDoc
@@ -87,6 +88,10 @@ fun RefileSheet(
         Column(Modifier.padding(horizontal = 14.dp)) {
             state.archiveTarget?.let { target ->
                 ArchiveRow(sub = archiveCrumb(target), onClick = onArchive)
+                Spacer(Modifier.height(10.dp))
+            }
+            state.lastUsedTarget?.let { target ->
+                LastUsedRow(sub = archiveCrumb(target), onClick = onPickLastUsed)
                 Spacer(Modifier.height(10.dp))
             }
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -220,6 +225,33 @@ private fun ArchiveRow(sub: String, onClick: () -> Unit) {
         Column(Modifier.weight(1f)) {
             Text(
                 "Archive",
+                fontFamily = PlexSans, fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp, color = c.ink,
+            )
+            Text(sub, fontFamily = PlexSans, fontSize = 11.5.sp, color = c.ink2)
+        }
+        Text("→", fontFamily = PlexSans, fontSize = 14.sp, color = c.accent)
+    }
+}
+
+/** Pinned quick action for the destination of the most recent successful refile. */
+@Composable
+private fun LastUsedRow(sub: String, onClick: () -> Unit) {
+    val c = MaterialTheme.grove
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .border(1.dp, c.line, RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("↺", fontFamily = PlexMono, fontSize = 15.sp, color = c.accent)
+        Spacer(Modifier.width(10.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                "Last used location",
                 fontFamily = PlexSans, fontWeight = FontWeight.SemiBold,
                 fontSize = 14.sp, color = c.ink,
             )

--- a/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
@@ -14,6 +14,7 @@ import com.rrajath.grove.org.OrgParser
 import com.rrajath.grove.org.OrgTimestamp
 import com.rrajath.grove.settings.NotebookDisplayNameMode
 import com.rrajath.grove.sync.SyncState
+import com.rrajath.grove.vault.Vault
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -194,6 +195,8 @@ data class RefileUiState(
     val path: List<Int> = emptyList(),
     /** Effective `ARCHIVE` target for the source headline (nearest-ancestor-wins), if any. */
     val archiveTarget: ArchiveTarget? = null,
+    /** Destination of the most recent successful refile, if any. */
+    val lastUsedTarget: ArchiveTarget? = null,
 )
 
 class DocumentViewModel(private val app: GroveApplication) : ViewModel() {
@@ -460,7 +463,11 @@ class DocumentViewModel(private val app: GroveApplication) : ViewModel() {
         viewModelScope.launch {
             val notebooks = app.vault.value?.notebooks().orEmpty()
                 .map { RefileNotebook(it.fileName, it.noteCount) }
-            _refile.value = _refile.value?.copy(notebooks = notebooks)
+            val settings = app.settingsRepository.settings.first()
+            val lastUsedTarget = settings.lastRefileFile?.let { fileName ->
+                ArchiveTarget(fileName, settings.lastRefileHeadingPath.split('/').filter { it.isNotEmpty() })
+            }
+            _refile.value = _refile.value?.copy(notebooks = notebooks, lastUsedTarget = lastUsedTarget)
         }
     }
 
@@ -498,8 +505,9 @@ class DocumentViewModel(private val app: GroveApplication) : ViewModel() {
         val loaded = _state.value as? DocumentUiState.Loaded ?: return
         val destFile = picker.pickedFile ?: return
         val source = loaded.document.headlineAtLine(picker.sourceLine) ?: return
+        val headingPath = picker.path.mapNotNull { picker.pickedDoc?.headlineAtLine(it)?.title }
         _refile.value = null
-        refileTo(source, destFile, picker.path.lastOrNull())
+        refileTo(source, destFile, picker.path.lastOrNull(), headingPath)
     }
 
     /** One-tap archive: refile the source subtree straight to its resolved `ARCHIVE` target, creating any missing file/heading. */
@@ -511,59 +519,103 @@ class DocumentViewModel(private val app: GroveApplication) : ViewModel() {
         val source = loaded.document.headlineAtLine(picker.sourceLine) ?: return
         _refile.value = null
         val sourceEnd = loaded.document.subtreeEndLine(source)
-        val archiveLabel = (listOf(target.fileName.removeSuffix(".org")) + target.headingPath)
-            .joinToString(" › ")
         viewModelScope.launch {
-            if (target.fileName == loaded.fileName) {
-                val result = withContext(Dispatchers.Default) {
-                    val subtree = OrgMutations.subtreeText(loaded.document, source)
-                    val afterDelete = OrgParser.parse(
-                        OrgMutations.deleteSubtree(loaded.document, source),
-                        loaded.document.keywords,
-                    )
-                    val (docAfterPath, destHeadline) =
-                        ArchiveLocation.findOrCreateHeadingPath(afterDelete, target.headingPath)
-                    val (finalText, _) = OrgMutations.refileInsert(docAfterPath, destHeadline, subtree)
-                    finalText to OrgParser.parse(finalText, loaded.document.keywords)
-                }
-                undoSnapshot = UndoSnapshot(listOf(loaded.fileName to loaded.document.text))
-                _focusedLine.value = null
-                _state.value = DocumentUiState.Loaded(loaded.fileName, result.second)
-                vault.save(loaded.fileName, result.first)
-                app.syncManager.requestSync("archive")
-                showSnack("Archived to $archiveLabel")
-            } else {
-                if (vault.open(target.fileName) == null) {
-                    vault.createNotebook(target.fileName)
-                }
-                val destDoc = vault.open(target.fileName)
-                if (destDoc == null) {
-                    showToast("Couldn't open ${target.fileName.removeSuffix(".org")}")
-                    return@launch
-                }
-                val (newSourceText, newDestText, newSourceDoc) = withContext(Dispatchers.Default) {
-                    val subtree = OrgMutations.subtreeText(loaded.document, source)
-                    val srcText = OrgMutations.deleteSubtree(loaded.document, source)
-                    val (docAfterPath, destHeadline) =
-                        ArchiveLocation.findOrCreateHeadingPath(destDoc, target.headingPath)
-                    val (dstText, _) = OrgMutations.refileInsert(docAfterPath, destHeadline, subtree)
-                    Triple(srcText, dstText, OrgParser.parse(srcText, loaded.document.keywords))
-                }
-                undoSnapshot = UndoSnapshot(
-                    listOf(loaded.fileName to loaded.document.text, target.fileName to destDoc.text)
-                )
-                _focusedLine.value = null
-                _state.value = DocumentUiState.Loaded(loaded.fileName, newSourceDoc)
-                vault.save(loaded.fileName, newSourceText)
-                vault.save(target.fileName, newDestText)
-                app.syncManager.requestSync("archive")
-                showSnack("Archived to $archiveLabel")
-            }
+            refileToResolvedTarget(
+                loaded, vault, source, target,
+                verb = "Archived", syncReason = "archive", createFileIfMissing = true,
+            )
             dropFavoritesInRange(loaded.fileName, source.lineIndex until sourceEnd)
         }
     }
 
-    private fun refileTo(source: OrgHeadline, destFile: String, targetLine: Int?) {
+    /** One-tap refile straight to the destination of the most recent successful refile. */
+    fun refileToLastUsed() {
+        val picker = _refile.value ?: return
+        val target = picker.lastUsedTarget ?: return
+        val loaded = _state.value as? DocumentUiState.Loaded ?: return
+        val vault = app.vault.value ?: return
+        val source = loaded.document.headlineAtLine(picker.sourceLine) ?: return
+        _refile.value = null
+        val sourceEnd = loaded.document.subtreeEndLine(source)
+        viewModelScope.launch {
+            refileToResolvedTarget(
+                loaded, vault, source, target,
+                verb = "Refiled", syncReason = "refile", createFileIfMissing = false,
+            )
+            dropFavoritesInRange(loaded.fileName, source.lineIndex until sourceEnd)
+        }
+    }
+
+    /** Shared refile-to-a-resolved-path logic behind both [refileToArchive] and [refileToLastUsed]. */
+    private suspend fun refileToResolvedTarget(
+        loaded: DocumentUiState.Loaded,
+        vault: Vault,
+        source: OrgHeadline,
+        target: ArchiveTarget,
+        verb: String,
+        syncReason: String,
+        createFileIfMissing: Boolean,
+    ) {
+        val label = (listOf(target.fileName.removeSuffix(".org")) + target.headingPath).joinToString(" › ")
+        if (target.fileName == loaded.fileName) {
+            val result = withContext(Dispatchers.Default) {
+                val subtree = OrgMutations.subtreeText(loaded.document, source)
+                val afterDelete = OrgParser.parse(
+                    OrgMutations.deleteSubtree(loaded.document, source),
+                    loaded.document.keywords,
+                )
+                val (docAfterPath, destHeadline) =
+                    ArchiveLocation.findOrCreateHeadingPath(afterDelete, target.headingPath)
+                val (finalText, _) = OrgMutations.refileInsert(docAfterPath, destHeadline, subtree)
+                finalText to OrgParser.parse(finalText, loaded.document.keywords)
+            }
+            undoSnapshot = UndoSnapshot(listOf(loaded.fileName to loaded.document.text))
+            _focusedLine.value = null
+            _state.value = DocumentUiState.Loaded(loaded.fileName, result.second)
+            vault.save(loaded.fileName, result.first)
+            app.syncManager.requestSync(syncReason)
+            showSnack("$verb to $label")
+        } else {
+            if (vault.open(target.fileName) == null) {
+                if (createFileIfMissing) {
+                    vault.createNotebook(target.fileName)
+                } else {
+                    showToast("Couldn't open ${target.fileName.removeSuffix(".org")}")
+                    return
+                }
+            }
+            val destDoc = vault.open(target.fileName)
+            if (destDoc == null) {
+                showToast("Couldn't open ${target.fileName.removeSuffix(".org")}")
+                return
+            }
+            val (newSourceText, newDestText, newSourceDoc) = withContext(Dispatchers.Default) {
+                val subtree = OrgMutations.subtreeText(loaded.document, source)
+                val srcText = OrgMutations.deleteSubtree(loaded.document, source)
+                val (docAfterPath, destHeadline) =
+                    ArchiveLocation.findOrCreateHeadingPath(destDoc, target.headingPath)
+                val (dstText, _) = OrgMutations.refileInsert(docAfterPath, destHeadline, subtree)
+                Triple(srcText, dstText, OrgParser.parse(srcText, loaded.document.keywords))
+            }
+            undoSnapshot = UndoSnapshot(
+                listOf(loaded.fileName to loaded.document.text, target.fileName to destDoc.text)
+            )
+            _focusedLine.value = null
+            _state.value = DocumentUiState.Loaded(loaded.fileName, newSourceDoc)
+            vault.save(loaded.fileName, newSourceText)
+            vault.save(target.fileName, newDestText)
+            app.syncManager.requestSync(syncReason)
+            showSnack("$verb to $label")
+        }
+    }
+
+    private fun rememberRefileTarget(fileName: String, headingPath: List<String>) {
+        viewModelScope.launch {
+            app.settingsRepository.setLastRefileTarget(fileName, headingPath)
+        }
+    }
+
+    private fun refileTo(source: OrgHeadline, destFile: String, targetLine: Int?, headingPath: List<String>) {
         val loaded = _state.value as? DocumentUiState.Loaded ?: return
         val vault = app.vault.value ?: return
         val sourceEnd = loaded.document.subtreeEndLine(source)
@@ -585,6 +637,7 @@ class DocumentViewModel(private val app: GroveApplication) : ViewModel() {
                 vault.save(loaded.fileName, result.first)
                 app.syncManager.requestSync("refile")
                 showSnack("Refiled to $destLabel › ${targetTitle ?: "top level"}")
+                rememberRefileTarget(destFile, headingPath)
             } else {
                 val destDoc = vault.open(destFile)
                 if (destDoc == null) {
@@ -607,6 +660,7 @@ class DocumentViewModel(private val app: GroveApplication) : ViewModel() {
                 vault.save(destFile, newDestText)
                 app.syncManager.requestSync("refile")
                 showSnack("Refiled to $destLabel › ${target?.title ?: "top level"}")
+                rememberRefileTarget(destFile, headingPath)
             }
             dropFavoritesInRange(loaded.fileName, source.lineIndex until sourceEnd)
         }

--- a/app/src/test/java/com/rrajath/grove/org/OrgParserTest.kt
+++ b/app/src/test/java/com/rrajath/grove/org/OrgParserTest.kt
@@ -146,6 +146,14 @@ class OrgParserTest {
     }
 
     @Test
+    fun `tags with dashes are recognized as tags`() {
+        val doc = OrgParser.parse("* A heading :floating-note:\n")
+        val h = doc.headlines.first()
+        assertEquals("A heading", h.title)
+        assertEquals(listOf("floating-note"), h.tags)
+    }
+
+    @Test
     fun `indented or starless lines are not headlines`() {
         val doc = OrgParser.parse(golden("edge-cases.org"))
         assertNull(doc.headlines.firstOrNull { it.title.contains("Also not a heading") })


### PR DESCRIPTION
## Summary

- Tags with a dash (e.g. `:floating-note:`) were not recognized as tags — they were treated as part of the heading title. Both the org parser and the editor's syntax highlighter used a tag regex missing `-` from the allowed character set; fixed in both places.
- The refile sheet's default-location shortcuts (Archive) now also include a **"Last used location"** row, right below Archive and above the file/heading drill-down. The destination of the most recent successful refile is persisted and offered as a one-tap target. Archiving intentionally does not update this — it follows org-mode's convention of keeping the archive shortcut separate from refile history.
- In read mode, a heading whose body starts with a standalone inactive/active timestamp followed by content on the next line was rendering the content right next to the timestamp with just a space between them. The content now starts on its own line under the timestamp, matching the source file's layout.

## Test plan

- [ ] Added a unit test (`OrgParserTest`) confirming `:floating-note:` parses as a tag.
- [ ] Manually verify in the app: refile a note, reopen the refile sheet, and confirm "Last used location" appears and refiles to the same destination.
- [ ] Manually verify in read mode: a heading with `[inactive timestamp]` on its own line followed by body text renders the text on a new line below the timestamp.
- [ ] `./gradlew testDebugUnitTest` (could not be run in this session — see note below)

Note: I wasn't able to run the Gradle build in this session (the wrapper needs Gradle 9.1.0, which this sandbox couldn't download due to an org egress policy blocking the GitHub release redirect). Changes were reviewed manually and the regex/timestamp-detection logic was verified against equivalent standalone scripts.


---
_Generated by [Claude Code](https://claude.ai/code/session_017JMY2MB91PAtFGWHF9vt4t)_