### PR TITLE
Fix app shortcut deep links, notebook sort, FAB scrim, autosave check mark, link button

### DIFF
--- a/app/src/main/java/com/rrajath/grove/MainActivity.kt
+++ b/app/src/main/java/com/rrajath/grove/MainActivity.kt
@@ -7,6 +7,9 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
@@ -15,23 +18,33 @@ import com.rrajath.grove.capture.SharedPayload
 import com.rrajath.grove.ui.GroveApp
 
 class MainActivity : ComponentActivity() {
+    // grove:// deep links (shortcuts, widget, notification) arrive as the
+    // launch Intent on a cold start or via onNewIntent on a warm one
+    // (singleTask launchMode). Navigation Compose does not consume the
+    // hosting Activity's Intent on its own, so it's threaded through as
+    // Compose state and handed to NavController.handleDeepLink explicitly.
+    private var deepLinkIntent by mutableStateOf<Intent?>(null)
+
     @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         consumeShareIntent(intent)
+        deepLinkIntent = intent
         setContent {
             // Expose Compose testTags as Android resource-ids so Macrobenchmark /
             // UiAutomator can target views by tag (e.g. By.res("outline_list")).
             Box(Modifier.fillMaxSize().semantics { testTagsAsResourceId = true }) {
-                GroveApp()
+                GroveApp(deepLinkIntent = deepLinkIntent)
             }
         }
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        setIntent(intent)
         consumeShareIntent(intent)
+        deepLinkIntent = intent
     }
 
     private fun consumeShareIntent(intent: Intent?) {

--- a/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
@@ -46,7 +46,10 @@ import com.rrajath.grove.ui.theme.grove
 import kotlinx.coroutines.launch
 
 @Composable
-fun GroveApp(viewModel: AppViewModel = viewModel(factory = AppViewModel.Factory)) {
+fun GroveApp(
+    deepLinkIntent: android.content.Intent? = null,
+    viewModel: AppViewModel = viewModel(factory = AppViewModel.Factory),
+) {
     val settings by viewModel.settings.collectAsStateWithLifecycle()
     // Wait for the first DataStore emission so theme and start destination don't flash.
     val loaded = settings ?: return
@@ -66,7 +69,7 @@ fun GroveApp(viewModel: AppViewModel = viewModel(factory = AppViewModel.Factory)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
     GroveTheme(theme = loaded.theme, fontSize = loaded.fontSize) {
-        GroveNavigation(loaded, viewModel)
+        GroveNavigation(loaded, viewModel, deepLinkIntent)
     }
 }
 
@@ -90,7 +93,11 @@ private fun vaultDisplayPath(treeUri: String?): String {
 }
 
 @Composable
-private fun GroveNavigation(settings: GroveSettings, viewModel: AppViewModel) {
+private fun GroveNavigation(
+    settings: GroveSettings,
+    viewModel: AppViewModel,
+    deepLinkIntent: android.content.Intent? = null,
+) {
     val navController = rememberNavController()
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
@@ -105,6 +112,16 @@ private fun GroveNavigation(settings: GroveSettings, viewModel: AppViewModel) {
     val pendingShare by app.pendingShare.collectAsStateWithLifecycle()
     LaunchedEffect(pendingShare) {
         if (pendingShare != null) viewModel.consumeSharedContent()
+    }
+
+    // Launcher shortcuts, the capture widget, and the persistent capture
+    // notification all launch grove:// VIEW intents; NavHost doesn't consume
+    // the hosting Activity's intent on its own, so route it through here on
+    // both cold start and a warm-start onNewIntent (see MainActivity).
+    LaunchedEffect(deepLinkIntent) {
+        if (deepLinkIntent?.action == android.content.Intent.ACTION_VIEW && deepLinkIntent.data != null) {
+            navController.handleDeepLink(deepLinkIntent)
+        }
     }
 
     fun closeDrawerAnd(action: () -> Unit) {

--- a/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
@@ -169,6 +169,9 @@ fun CaptureEditorScreen(
     // Mirrors the note editor's auto-save indicator: a tappable check mark
     // in the top bar once the draft has been auto-saved at least once.
     var lastAutoSavedAt by remember { mutableStateOf<LocalTime?>(null) }
+    // Text as of the last auto-save, so the check mark can tell whether the
+    // draft has drifted since then (grey) or still matches disk (green).
+    var lastAutoSavedText by remember(expanded) { mutableStateOf(initialText) }
     // Blinks the check mark twice on each auto-save instead of a toast;
     // tapping the check mark still shows a "saved at" toast on demand.
     val checkAlpha = remember { Animatable(1f) }
@@ -205,6 +208,7 @@ fun CaptureEditorScreen(
         if (value.text != initialText && !CaptureInserter.hasBlankHeading(value.text)) {
             viewModel.autosave(template, value.text, context)
             lastAutoSavedAt = LocalTime.now()
+            lastAutoSavedText = value.text
         }
     }
 
@@ -234,7 +238,10 @@ fun CaptureEditorScreen(
                         Icon(
                             Icons.Default.Check,
                             contentDescription = "Auto saved",
-                            tint = c.green,
+                            // Green while the draft matches what's on disk (and
+                            // blinks right after a save); grey again the moment a
+                            // keystroke makes it dirty, until the next auto-save.
+                            tint = if (value.text != lastAutoSavedText) c.ink3 else c.green,
                             modifier = Modifier
                                 .alpha(checkAlpha.value)
                                 .clip(RoundedCornerShape(10.dp))

--- a/app/src/main/java/com/rrajath/grove/ui/capture/CapturePickerScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/capture/CapturePickerScreen.kt
@@ -54,6 +54,9 @@ fun CapturePickerSheet(
         sheetState = sheetState,
         containerColor = c.surface,
         shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+        // Cap the scrim at 80% instead of Material3's fully-opaque default
+        // scrim token, so the notebooks list stays faintly visible behind it.
+        scrimColor = MaterialTheme.colorScheme.scrim.copy(alpha = 0.8f),
     ) {
         Column(Modifier.padding(bottom = 26.dp)) {
             Row(

--- a/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
@@ -213,7 +213,10 @@ fun EditNoteScreen(
                         Icon(
                             Icons.Default.Check,
                             contentDescription = "Auto saved",
-                            tint = c.green,
+                            // Green while the buffer matches what's on disk (and
+                            // blinks right after a save); grey again the moment a
+                            // keystroke makes it dirty, until the next auto-save.
+                            tint = if (state.dirty) c.ink3 else c.green,
                             modifier = Modifier
                                 .alpha(checkAlpha.value)
                                 .clip(RoundedCornerShape(10.dp))

--- a/app/src/main/java/com/rrajath/grove/ui/editor/EditorToolbar.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/EditorToolbar.kt
@@ -141,14 +141,19 @@ internal fun insertAtCursor(value: TextFieldValue, snippet: String): TextFieldVa
 
 /**
  * Insert an org link template with named placeholders and pre-select "link" so
- * the user can type the URL over it, then move to "description".
+ * the user can type the URL over it, then move to "description". A non-empty
+ * selection is consumed as the description instead of the "description"
+ * placeholder, so e.g. selecting "my note" and tapping link yields
+ * [[link][my note]] with "link" highlighted to type the URL over.
  */
 internal fun insertLinkTemplate(value: TextFieldValue): TextFieldValue {
-    val at = value.selection.start
-    val template = "[[link][description]]"
-    val linkStart = at + 2 // just inside the opening "[["
+    val sel = value.selection
+    val text = value.text
+    val description = if (sel.collapsed) "description" else text.substring(sel.min, sel.max)
+    val template = "[[link][$description]]"
+    val linkStart = sel.min + 2 // just inside the opening "[["
     return TextFieldValue(
-        value.text.substring(0, at) + template + value.text.substring(at),
+        text.substring(0, sel.min) + template + text.substring(sel.max),
         TextRange(linkStart, linkStart + "link".length),
     )
 }

--- a/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
@@ -83,7 +83,7 @@ class NotebooksViewModel(private val app: GroveApplication) : ViewModel() {
             }
             .sortedWith(
                 compareBy<NotebookItem> { if (it.isPinned) it.pinnedIndex else Int.MAX_VALUE }
-                    .thenBy { it.fileName.lowercase() }
+                    .thenBy { it.displayName.lowercase() }
             )
     }.distinctUntilChanged()
 

--- a/app/src/test/java/com/rrajath/grove/ui/NotebookPinOrderTest.kt
+++ b/app/src/test/java/com/rrajath/grove/ui/NotebookPinOrderTest.kt
@@ -13,18 +13,22 @@ import org.junit.Test
  */
 class NotebookPinOrderTest {
 
-    private fun item(name: String, pinnedIndex: Int = -1) = NotebookItem(
+    private fun item(name: String, pinnedIndex: Int = -1, displayName: String = name) = NotebookItem(
         fileName = name,
         noteCount = 0,
         lastModified = 0L,
         hasConflict = false,
         pinnedIndex = pinnedIndex,
+        displayName = displayName,
     )
 
+    // Mirrors NotebooksViewModel.notebookItems' sortedWith: unpinned notebooks
+    // sort by displayName, which is already resolved to either the file name
+    // or the cached title depending on Settings' notebookDisplayNameMode.
     private fun sortedLike(items: List<NotebookItem>): List<NotebookItem> =
         items.sortedWith(
             compareBy<NotebookItem> { if (it.isPinned) it.pinnedIndex else Int.MAX_VALUE }
-                .thenBy { it.fileName.lowercase() }
+                .thenBy { it.displayName.lowercase() }
         )
 
     @Test
@@ -81,6 +85,31 @@ class NotebookPinOrderTest {
         val items = listOf(item("z.org"), item("a.org"), item("m.org"))
         val sorted = sortedLike(items)
         assertEquals(listOf("a.org", "m.org", "z.org"), sorted.map { it.fileName })
+    }
+
+    @Test
+    fun `unpinned items sort by title when display name mode is title`() {
+        // File names would sort z, a, m — but with the title display mode
+        // (NotebookDisplayNameMode.TITLE), displayName carries the #+TITLE:
+        // instead, and that's what unpinned notebooks must sort by.
+        val items = listOf(
+            item("z.org", displayName = "Alpha notes"),
+            item("a.org", displayName = "Zeta notes"),
+            item("m.org", displayName = "Middle notes"),
+        )
+        val sorted = sortedLike(items)
+        assertEquals(listOf("z.org", "m.org", "a.org"), sorted.map { it.fileName })
+    }
+
+    @Test
+    fun `pinned items keep pin order regardless of display name mode`() {
+        val items = listOf(
+            item("z.org", pinnedIndex = 0, displayName = "Zeta notes"),
+            item("a.org", pinnedIndex = 1, displayName = "Alpha notes"),
+            item("m.org", displayName = "Middle notes"),
+        )
+        val sorted = sortedLike(items)
+        assertEquals(listOf("z.org", "a.org", "m.org"), sorted.map { it.fileName })
     }
 
     @Test

--- a/app/src/test/java/com/rrajath/grove/ui/editor/EditorToolbarTest.kt
+++ b/app/src/test/java/com/rrajath/grove/ui/editor/EditorToolbarTest.kt
@@ -1,0 +1,39 @@
+package com.rrajath.grove.ui.editor
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EditorToolbarTest {
+
+    @Test
+    fun `link button with no selection inserts placeholders and highlights link`() {
+        val value = TextFieldValue("Hello ", TextRange(6))
+        val result = insertLinkTemplate(value)
+
+        assertEquals("Hello [[link][description]]", result.text)
+        // "link" (between "Hello [[" and "][") is selected, ready to type the URL.
+        assertEquals(TextRange(8, 12), result.selection)
+    }
+
+    @Test
+    fun `link button with a selection replaces it with the description and highlights link`() {
+        // "my note" spans indices 4..10 of "See my note here".
+        val value = TextFieldValue("See my note here", TextRange(4, 11))
+        val result = insertLinkTemplate(value)
+
+        assertEquals("See [[link][my note]] here", result.text)
+        assertEquals(TextRange(6, 10), result.selection)
+    }
+
+    @Test
+    fun `link button with a reversed selection still uses the selected text`() {
+        // TextFieldValue selections can run start > end when the drag goes right-to-left.
+        val value = TextFieldValue("See my note here", TextRange(11, 4))
+        val result = insertLinkTemplate(value)
+
+        assertEquals("See [[link][my note]] here", result.text)
+        assertEquals(TextRange(6, 10), result.selection)
+    }
+}


### PR DESCRIPTION
- Wire grove:// intents through NavController.handleDeepLink() on both cold
  start and onNewIntent; Navigation Compose never consumed the Activity's
  intent on its own, so launcher shortcuts (and the widget/notification
  deep links) opened the app but never navigated anywhere.
- Sort unpinned notebooks by displayName instead of fileName, so the
  filename/title display mode in Settings actually drives sort order.
- Cap the capture FAB bottom sheet's scrim at 80% opacity instead of
  Material3's fully-opaque default scrim token.
- Auto-save check mark now turns grey as soon as the buffer is dirty
  (a keystroke since the last save) instead of staying green until the
  next auto-save's blink.
- Link toolbar button now consumes a text selection as the link's
  description instead of leaving it untouched next to the template, and
  still leaves "link" highlighted to type the URL over.