### PR TITLE
Add checklist list items with configurable read-mode tap-to-cycle states

### DIFF
--- a/app/src/main/java/com/rrajath/grove/org/LineEditing.kt
+++ b/app/src/main/java/com/rrajath/grove/org/LineEditing.kt
@@ -9,7 +9,9 @@ data class TextEdit(val text: String, val cursor: Int)
  */
 object LineEditing {
 
-    private val LIST_ITEM = Regex("""^(\s*)([-+]|\d+[.)])( +)(.*)$""")
+    // Groups: 1 indent, 2 bullet, 3 spaces after bullet, 4 checkbox marker
+    // ("[ ]"/"[x]"/"[X]"/"[-]", or absent), 5 spaces after the checkbox, 6 content.
+    private val LIST_ITEM = Regex("""^(\s*)([-+]|\d+[.)])( +)(\[[ Xx-]\])?( *)(.*)$""")
     private val NUMBERED = Regex("""^(\d+)([.)])$""")
     private val EMPTY_HEADING = Regex("""^\*+ ?$""")
 
@@ -17,8 +19,10 @@ object LineEditing {
      * Org/markdown style list continuation. Call after an edit that may have
      * been the Enter key: if [newText] is [oldText] with a single newline typed
      * at [cursor] and the line before it is a list item, either continue the
-     * list (`- `, `+ `, `3. `→`4. `) or — when the item was empty — remove the
-     * dangling bullet instead. Returns null when the edit wasn't that.
+     * list (`- `, `+ `, `3. `→`4. `, `- [ ] `→`- [ ] `) or — when the item was
+     * empty — remove the dangling bullet instead. A continued checklist item
+     * always restarts unchecked, regardless of the previous item's state.
+     * Returns null when the edit wasn't that.
      */
     fun continueListOnEnter(oldText: String, newText: String, cursor: Int): TextEdit? {
         if (newText.length != oldText.length + 1) return null
@@ -28,7 +32,7 @@ object LineEditing {
         val lineStart = newText.lastIndexOf('\n', cursor - 2) + 1
         val prevLine = newText.substring(lineStart, cursor - 1)
         val item = LIST_ITEM.matchEntire(prevLine) ?: return null
-        val (indent, bullet, _, content) = item.destructured
+        val (indent, bullet, _, checkbox, _, content) = item.destructured
 
         return if (content.isBlank()) {
             // Enter on an empty item ends the list: drop the bullet, no new line.
@@ -38,7 +42,8 @@ object LineEditing {
                 ?.destructured
                 ?.let { (n, suffix) -> "${n.toLong() + 1}$suffix" }
                 ?: bullet
-            val insert = "$indent$nextBullet "
+            val checkboxPart = if (checkbox.isNotEmpty()) "[ ] " else ""
+            val insert = "$indent$nextBullet $checkboxPart"
             TextEdit(
                 newText.substring(0, cursor) + insert + newText.substring(cursor),
                 cursor + insert.length,
@@ -60,13 +65,13 @@ object LineEditing {
         val lineEnd = text.indexOf('\n', at).let { if (it == -1) text.length else it }
         val line = text.substring(lineStart, lineEnd)
         val item = LIST_ITEM.matchEntire(line) ?: return null
-        val (indent, bullet, spaces, content) = item.destructured
+        val (indent, bullet, spaces, checkbox, checkboxSpace, content) = item.destructured
         val newLine = if (delta > 0) {
             // A fresh sub-list restarts numbering at 1 (unordered bullets unchanged).
             val newBullet = NUMBERED.matchEntire(bullet)
                 ?.destructured?.let { (_, suffix) -> "1$suffix" }
                 ?: bullet
-            INDENT_STEP + indent + newBullet + spaces + content
+            INDENT_STEP + indent + newBullet + spaces + checkbox + checkboxSpace + content
         } else {
             if (indent.isEmpty()) return null
             line.substring(minOf(INDENT_STEP.length, indent.length))

--- a/app/src/main/java/com/rrajath/grove/org/OrgMutations.kt
+++ b/app/src/main/java/com/rrajath/grove/org/OrgMutations.kt
@@ -77,6 +77,29 @@ object OrgMutations {
         }
     }
 
+    private val CHECKBOX_LINE = Regex("""^(\s*(?:[-+]|\d+[.)])\s+)\[([ Xx-])\](.*)$""")
+
+    /**
+     * Read mode: tap-cycle a checklist item's box forward through [states] (in
+     * order, wrapping around). [lineIndex] is absolute into [doc.lines] — the
+     * caller resolves a [BlockParser.ListItem]'s body-relative `line` against
+     * the owning headline's `bodyStart` first. A box whose current mark isn't
+     * one of [states] (e.g. `[-]` on a file using the two-state config) jumps
+     * to the first state rather than the one after it. Returns null when the
+     * line isn't a checkbox list item.
+     */
+    fun toggleCheckbox(doc: OrgDocument, lineIndex: Int, states: List<Char>): String? {
+        if (lineIndex !in doc.lines.indices) return null
+        val m = CHECKBOX_LINE.matchEntire(doc.lines[lineIndex]) ?: return null
+        val (prefix, mark, rest) = m.destructured
+        val current = if (mark == "x") "X" else mark
+        val idx = states.indexOf(current.first())
+        val next = if (idx == -1) states.first() else states[(idx + 1) % states.size]
+        val lines = doc.lines.toMutableList()
+        lines[lineIndex] = "$prefix[$next]$rest"
+        return lines.joinToString("\n")
+    }
+
     // --- structural edits ---
 
     fun subtreeText(doc: OrgDocument, h: OrgHeadline): String =

--- a/app/src/main/java/com/rrajath/grove/settings/Preferences.kt
+++ b/app/src/main/java/com/rrajath/grove/settings/Preferences.kt
@@ -61,3 +61,17 @@ enum class NotebookDisplayNameMode(val storageKey: String) {
             entries.firstOrNull { it.storageKey == value } ?: FILENAME
     }
 }
+
+/**
+ * Read mode: how many states a tap cycles a checklist item's box through.
+ * [marks] is the tap order, e.g. two-state `[ ]` → `[X]` → `[ ]`…
+ */
+enum class ChecklistStates(val storageKey: String, val marks: List<Char>) {
+    TWO("two", listOf(' ', 'X')),
+    THREE("three", listOf(' ', '-', 'X'));
+
+    companion object {
+        fun fromStorage(value: String?): ChecklistStates =
+            entries.firstOrNull { it.storageKey == value } ?: TWO
+    }
+}

--- a/app/src/main/java/com/rrajath/grove/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/rrajath/grove/settings/SettingsRepository.kt
@@ -55,6 +55,8 @@ data class GroveSettings(
     val lastRefileFile: String? = null,
     /** '/'-separated heading path within [lastRefileFile]; empty = top level. */
     val lastRefileHeadingPath: String = "",
+    /** Read mode: how many states tapping a checklist item cycles through. */
+    val checklistStates: ChecklistStates = ChecklistStates.TWO,
 ) {
     companion object {
         const val DEFAULT_TODO_KEYWORDS = "TODO IN-PROGRESS | DONE CANCELLED"
@@ -91,6 +93,7 @@ class SettingsRepository(private val context: Context) {
         val notebookDisplayNameMode = stringPreferencesKey("notebook_display_name_mode")
         val lastRefileFile = stringPreferencesKey("last_refile_file")
         val lastRefileHeadingPath = stringPreferencesKey("last_refile_heading_path")
+        val checklistStates = stringPreferencesKey("checklist_states")
     }
 
     val settings: Flow<GroveSettings> = context.settingsDataStore.data.map { prefs ->
@@ -121,6 +124,7 @@ class SettingsRepository(private val context: Context) {
             notebookDisplayNameMode = NotebookDisplayNameMode.fromStorage(prefs[Keys.notebookDisplayNameMode]),
             lastRefileFile = prefs[Keys.lastRefileFile],
             lastRefileHeadingPath = prefs[Keys.lastRefileHeadingPath] ?: "",
+            checklistStates = ChecklistStates.fromStorage(prefs[Keys.checklistStates]),
         )
     }
 
@@ -172,6 +176,7 @@ class SettingsRepository(private val context: Context) {
             p[Keys.showHeaderTags] = s.showHeaderTags
             p[Keys.showPropertyDrawers] = s.showPropertyDrawers
             p[Keys.notebookDisplayNameMode] = s.notebookDisplayNameMode.storageKey
+            p[Keys.checklistStates] = s.checklistStates.storageKey
         }
     }
 
@@ -256,6 +261,10 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun setNotebookDisplayNameMode(mode: NotebookDisplayNameMode) {
         context.settingsDataStore.edit { it[Keys.notebookDisplayNameMode] = mode.storageKey }
+    }
+
+    suspend fun setChecklistStates(states: ChecklistStates) {
+        context.settingsDataStore.edit { it[Keys.checklistStates] = states.storageKey }
     }
 
     suspend fun setLastRefileTarget(fileName: String, headingPath: List<String>) {

--- a/app/src/main/java/com/rrajath/grove/settings/SettingsSerialization.kt
+++ b/app/src/main/java/com/rrajath/grove/settings/SettingsSerialization.kt
@@ -56,6 +56,7 @@ data class SettingsExport(
     val showHeaderTags: Boolean = true,
     val showPropertyDrawers: Boolean = true,
     val notebookDisplayNameMode: String = NotebookDisplayNameMode.FILENAME.storageKey,
+    val checklistStates: String = ChecklistStates.TWO.storageKey,
 ) {
     /** Map back onto [base], using the enums' tolerant `fromStorage` fallbacks. */
     fun applyTo(base: GroveSettings): GroveSettings = base.copy(
@@ -81,6 +82,7 @@ data class SettingsExport(
         showHeaderTags = showHeaderTags,
         showPropertyDrawers = showPropertyDrawers,
         notebookDisplayNameMode = NotebookDisplayNameMode.fromStorage(notebookDisplayNameMode),
+        checklistStates = ChecklistStates.fromStorage(checklistStates),
     )
 
     companion object {
@@ -109,6 +111,7 @@ data class SettingsExport(
             showHeaderTags = s.showHeaderTags,
             showPropertyDrawers = s.showPropertyDrawers,
             notebookDisplayNameMode = s.notebookDisplayNameMode.storageKey,
+            checklistStates = s.checklistStates.storageKey,
         )
     }
 }

--- a/app/src/main/java/com/rrajath/grove/ui/AppViewModel.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/AppViewModel.kt
@@ -10,6 +10,7 @@ import com.rrajath.grove.capture.ShareIntake
 import com.rrajath.grove.data.FavoriteNote
 import com.rrajath.grove.org.OrgMutations
 import com.rrajath.grove.search.SavedSearch
+import com.rrajath.grove.settings.ChecklistStates
 import com.rrajath.grove.settings.FontSizePreference
 import com.rrajath.grove.settings.GroveSettings
 import com.rrajath.grove.settings.NoteOpenMode
@@ -157,6 +158,9 @@ class AppViewModel(private val app: GroveApplication) : ViewModel() {
 
     fun setNotebookDisplayNameMode(mode: NotebookDisplayNameMode) =
         viewModelScope.launch { settingsRepository.setNotebookDisplayNameMode(mode) }
+
+    fun setChecklistStates(states: ChecklistStates) =
+        viewModelScope.launch { settingsRepository.setChecklistStates(states) }
 
     /** Write the current preferences as a JSON document to the user-picked [uri]. */
     fun exportSettings(uri: android.net.Uri) = viewModelScope.launch {

--- a/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
@@ -239,6 +239,7 @@ private fun GroveNavigation(
                             }
                         },
                         showPropertyDrawers = settings.showPropertyDrawers,
+                        checklistStates = settings.checklistStates,
                         favoriteLines = favoriteLinesFor(favorites, ref.fileName),
                     )
                 }
@@ -306,6 +307,7 @@ private fun GroveNavigation(
                     onSetShowHeaderTags = viewModel::setShowHeaderTags,
                     onSetShowPropertyDrawers = viewModel::setShowPropertyDrawers,
                     onSetNotebookDisplayNameMode = viewModel::setNotebookDisplayNameMode,
+                    onSetChecklistStates = viewModel::setChecklistStates,
                     onSetFontSize = viewModel::setFontSize,
                     onSetNoteOpenMode = viewModel::setDefaultNoteOpenMode,
                     onEditTemplate = { id ->

--- a/app/src/main/java/com/rrajath/grove/ui/screens/ReadNoteScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/ReadNoteScreen.kt
@@ -61,6 +61,7 @@ import com.rrajath.grove.org.OrgBlock
 import com.rrajath.grove.org.OrgDocument
 import com.rrajath.grove.org.OrgHeadline
 import com.rrajath.grove.org.OrgTimestamp
+import com.rrajath.grove.settings.ChecklistStates
 import com.rrajath.grove.ui.components.CollapsibleKvSection
 import com.rrajath.grove.ui.components.FavoriteStar
 import com.rrajath.grove.ui.components.GroveTopBar
@@ -93,6 +94,8 @@ fun ReadNoteScreen(
     onEdit: () -> Unit,
     /** Settings toggle: show collapsible sections for `:PROPERTIES:` drawers. */
     showPropertyDrawers: Boolean = true,
+    /** Settings: how many states tapping a checklist item cycles through. */
+    checklistStates: ChecklistStates = ChecklistStates.TWO,
     /** Line indices of favorited headlines in this file — marked with a ★. */
     favoriteLines: Set<Int> = emptySet(),
     viewModel: DocumentViewModel = viewModel(factory = DocumentViewModel.Factory),
@@ -169,6 +172,7 @@ fun ReadNoteScreen(
                             onOpenNote = onOpenNote,
                             fileName = noteRef.fileName,
                             onEditAt = onEdit,
+                            onToggleCheckbox = { line -> viewModel.toggleChecklistItem(line, checklistStates.marks) },
                             showPropertyDrawers = showPropertyDrawers,
                             favoriteLines = favoriteLines,
                         )
@@ -192,6 +196,7 @@ private fun NoteContent(
     fileName: String,
     onOpenNote: (NoteRef) -> Unit,
     onEditAt: () -> Unit,
+    onToggleCheckbox: (Int) -> Unit,
     listState: LazyListState,
     modifier: Modifier = Modifier,
     showPropertyDrawers: Boolean = true,
@@ -308,7 +313,7 @@ private fun NoteContent(
                         Spacer(Modifier.height(16.dp))
 
                         // Own body
-                        BodyBlocks(ownBody, openLink, onLinkLongPress, onEditAt)
+                        BodyBlocks(ownBody, headline.bodyStart, onToggleCheckbox, openLink, onLinkLongPress, onEditAt)
                     }
                 }
             }
@@ -366,7 +371,7 @@ private fun NoteContent(
                         } else {
                             Spacer(Modifier.height(8.dp))
                         }
-                        BodyBlocks(body, openLink, onLinkLongPress, onEditAt)
+                        BodyBlocks(body, child.bodyStart, onToggleCheckbox, openLink, onLinkLongPress, onEditAt)
                     }
                 }
             }
@@ -484,6 +489,9 @@ private fun PlanningChip(text: String, fg: Color, bg: Color) {
 @Composable
 private fun BodyBlocks(
     bodyLines: List<String>,
+    /** Absolute doc line of `bodyLines[0]`, to resolve a [OrgBlock.ListItem]'s body-relative `line`. */
+    lineOffset: Int,
+    onToggleCheckbox: (Int) -> Unit,
     openTarget: (String) -> Unit,
     onLinkLongPress: (String, Offset, LayoutCoordinates) -> Unit,
     onEditAt: () -> Unit,
@@ -525,24 +533,36 @@ private fun BodyBlocks(
             is OrgBlock.ListBlock -> {
                 Column(Modifier.padding(start = 8.dp)) {
                     block.items.forEachIndexed { i, item ->
-                        Row(Modifier.padding(vertical = 2.dp).padding(start = (item.indent * 4).dp)) {
+                        val done = item.checkbox == 'X' || item.checkbox == 'x'
+                        Row(
+                            Modifier.padding(vertical = 2.dp).padding(start = (item.indent * 4).dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
                             Text(
                                 when {
-                                    item.checkbox == 'X' || item.checkbox == 'x' -> "☑"
+                                    done -> "☑"
+                                    item.checkbox == '-' -> "◧"
                                     item.checkbox == ' ' -> "☐"
                                     item.ordered -> "${i + 1}."
                                     else -> "•"
                                 },
-                                fontFamily = PlexSerif, fontSize = 16.sp, color = c.ink2,
+                                fontFamily = PlexSerif, fontSize = 16.sp,
+                                color = if (done) c.ink3 else c.ink2,
+                                modifier = if (item.checkbox != null) {
+                                    Modifier
+                                        .clip(RoundedCornerShape(4.dp))
+                                        .clickable { onToggleCheckbox(lineOffset + item.line) }
+                                        .padding(4.dp)
+                                } else Modifier,
                             )
-                            Spacer(Modifier.width(10.dp))
+                            Spacer(Modifier.width(8.dp))
                             OrgText(
                                 item.text,
                                 onOpenLink = openTarget, onLinkLongPress = onLinkLongPress,
                                 onDoubleTapAt = onEditAt,
                                 style = TextStyle(
                                     fontFamily = PlexSerif, fontSize = 16.sp,
-                                    lineHeight = 1.55.em, color = c.ink,
+                                    lineHeight = 1.55.em, color = if (done) c.ink3 else c.ink,
                                 ),
                             )
                         }

--- a/app/src/main/java/com/rrajath/grove/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/SettingsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rrajath.grove.capture.CaptureTemplate
 import com.rrajath.grove.ui.capture.TemplatesViewModel
+import com.rrajath.grove.settings.ChecklistStates
 import com.rrajath.grove.settings.FontSizePreference
 import com.rrajath.grove.settings.GroveSettings
 import com.rrajath.grove.settings.NoteOpenMode
@@ -76,6 +77,7 @@ fun SettingsScreen(
     onSetVaultUri: (String) -> Unit,
     onSetShareTargetFile: (String) -> Unit,
     onSetNotebookDisplayNameMode: (NotebookDisplayNameMode) -> Unit,
+    onSetChecklistStates: (ChecklistStates) -> Unit,
     onExportSettings: (android.net.Uri) -> Unit,
     onImportSettings: (android.net.Uri) -> Unit,
     templatesViewModel: TemplatesViewModel = viewModel(factory = TemplatesViewModel.Factory),
@@ -343,6 +345,15 @@ fun SettingsScreen(
                         selectedIndex = settings.notebookDisplayNameMode.ordinal,
                         onSelect = { onSetNotebookDisplayNameMode(NotebookDisplayNameMode.entries[it]) },
                         modifier = Modifier.width(200.dp),
+                    )
+                }
+                RowDivider()
+                SettingsRow(label = "Checklist states") {
+                    SegmentedControl(
+                        options = listOf("2-state", "3-state"),
+                        selectedIndex = settings.checklistStates.ordinal,
+                        onSelect = { onSetChecklistStates(ChecklistStates.entries[it]) },
+                        modifier = Modifier.width(160.dp),
                     )
                 }
                 RowDivider()

--- a/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
@@ -425,6 +425,27 @@ class DocumentViewModel(private val app: GroveApplication) : ViewModel() {
         }
     }
 
+    /**
+     * Read mode: tap a checklist item to cycle its box through [states].
+     * [lineIndex] is absolute into the document (a [BlockParser.ListItem]'s
+     * body-relative line plus the owning headline's `bodyStart`).
+     */
+    fun toggleChecklistItem(lineIndex: Int, states: List<Char>) {
+        val loaded = _state.value as? DocumentUiState.Loaded ?: return
+        val vault = app.vault.value ?: return
+        viewModelScope.launch {
+            val newText = withContext(Dispatchers.Default) {
+                OrgMutations.toggleCheckbox(loaded.document, lineIndex, states)
+            } ?: return@launch
+            val newDoc = withContext(Dispatchers.Default) {
+                OrgParser.parse(newText, loaded.document.keywords)
+            }
+            _state.value = DocumentUiState.Loaded(loaded.fileName, newDoc)
+            vault.save(loaded.fileName, newText)
+            app.syncManager.requestSync("checklist toggled")
+        }
+    }
+
     fun setScheduled(headline: OrgHeadline, ts: OrgTimestamp?) =
         setPlanning(headline, "Scheduled", ts) { d, h -> OrgMutations.setScheduled(d, h, ts) }
 

--- a/app/src/test/java/com/rrajath/grove/org/LineEditingTest.kt
+++ b/app/src/test/java/com/rrajath/grove/org/LineEditingTest.kt
@@ -60,6 +60,70 @@ class LineEditingTest {
         assertEquals(8, edit.cursor)
     }
 
+    // --- checklist items ---
+
+    @Test
+    fun `checklist item continues with a fresh unchecked box`() {
+        val edit = pressEnter("- [ ] milk", 10)!!
+        assertEquals("- [ ] milk\n- [ ] ", edit.text)
+        assertEquals(edit.text.length, edit.cursor)
+    }
+
+    @Test
+    fun `checked item continues unchecked, not carrying the done state forward`() {
+        val edit = pressEnter("- [X] milk", 10)!!
+        assertEquals("- [X] milk\n- [ ] ", edit.text)
+    }
+
+    @Test
+    fun `in-progress item continues unchecked`() {
+        val edit = pressEnter("- [-] milk", 10)!!
+        assertEquals("- [-] milk\n- [ ] ", edit.text)
+    }
+
+    @Test
+    fun `numbered checklist item increments and keeps the checkbox`() {
+        val edit = pressEnter("1. [ ] first", 12)!!
+        assertEquals("1. [ ] first\n2. [ ] ", edit.text)
+    }
+
+    @Test
+    fun `checklist indentation is preserved`() {
+        val edit = pressEnter("  - [ ] nested", 14)!!
+        assertEquals("  - [ ] nested\n  - [ ] ", edit.text)
+    }
+
+    @Test
+    fun `enter on an empty checklist item removes it`() {
+        val edit = pressEnter("- [ ] a\n- [ ] ", 14)!!
+        assertEquals("- [ ] a\n", edit.text)
+        assertEquals(8, edit.cursor)
+    }
+
+    @Test
+    fun `enter on an empty checked item removes it`() {
+        val edit = pressEnter("- [X] a\n- [X] ", 14)!!
+        assertEquals("- [X] a\n", edit.text)
+    }
+
+    @Test
+    fun `checklist indent preserves the box state`() {
+        val edit = LineEditing.changeListIndent("- [ ] one\n- [X] two", 13, +1)!!
+        assertEquals("- [ ] one\n  - [X] two", edit.text)
+    }
+
+    @Test
+    fun `checklist outdent preserves the box state`() {
+        val edit = LineEditing.changeListIndent("- [ ] one\n  - [-] two", 15, -1)!!
+        assertEquals("- [ ] one\n- [-] two", edit.text)
+    }
+
+    @Test
+    fun `indenting a numbered checklist item restarts numbering and keeps the box`() {
+        val edit = LineEditing.changeListIndent("1. [ ] one\n2. [X] two", 17, +1)!!
+        assertEquals("1. [ ] one\n  1. [X] two", edit.text)
+    }
+
     @Test
     fun `non-list lines are untouched`() {
         assertNull(pressEnter("plain text", 10))

--- a/app/src/test/java/com/rrajath/grove/org/OrgMutationsTest.kt
+++ b/app/src/test/java/com/rrajath/grove/org/OrgMutationsTest.kt
@@ -402,4 +402,99 @@ class OrgMutationsTest {
         assertEquals("* Title", OrgMutations.headlineLine(1, null, null, "Title", emptyList()))
         assertEquals("* TODO", OrgMutations.headlineLine(1, "TODO", null, "", emptyList()))
     }
+
+    // --- toggleCheckbox ---
+
+    private val checklistDoc = OrgParser.parse(
+        """
+        * Groceries
+        - [ ] milk
+        - [X] eggs
+        - [-] bread
+          - [ ] nested
+        - plain item
+        not a list line
+        """.trimIndent() + "\n"
+    )
+
+    private val TWO_STATE = listOf(' ', 'X')
+    private val THREE_STATE = listOf(' ', '-', 'X')
+
+    @Test
+    fun `two-state toggle cycles open to done and back`() {
+        val line = checklistDoc.lines.indexOf("- [ ] milk")
+        val once = OrgMutations.toggleCheckbox(checklistDoc, line, TWO_STATE)!!
+        assertTrue(once.lines()[line] == "- [X] milk")
+        val redoc = OrgParser.parse(once)
+        val twice = OrgMutations.toggleCheckbox(redoc, line, TWO_STATE)!!
+        assertEquals("- [ ] milk", twice.lines()[line])
+    }
+
+    @Test
+    fun `three-state toggle cycles open to in-progress to done and back`() {
+        val line = checklistDoc.lines.indexOf("- [ ] milk")
+        val step1 = OrgMutations.toggleCheckbox(checklistDoc, line, THREE_STATE)!!
+        assertEquals("- [-] milk", step1.lines()[line])
+        val step2 = OrgMutations.toggleCheckbox(OrgParser.parse(step1), line, THREE_STATE)!!
+        assertEquals("- [X] milk", step2.lines()[line])
+        val step3 = OrgMutations.toggleCheckbox(OrgParser.parse(step2), line, THREE_STATE)!!
+        assertEquals("- [ ] milk", step3.lines()[line])
+    }
+
+    @Test
+    fun `toggling a done item under the two-state config unchecks it`() {
+        val line = checklistDoc.lines.indexOf("- [X] eggs")
+        val result = OrgMutations.toggleCheckbox(checklistDoc, line, TWO_STATE)!!
+        assertEquals("- [ ] eggs", result.lines()[line])
+    }
+
+    @Test
+    fun `a mark outside the configured states jumps to the first state`() {
+        // Document has an in-progress box, but settings are two-state only.
+        val line = checklistDoc.lines.indexOf("- [-] bread")
+        val result = OrgMutations.toggleCheckbox(checklistDoc, line, TWO_STATE)!!
+        assertEquals("- [ ] bread", result.lines()[line])
+    }
+
+    @Test
+    fun `lowercase x is treated as done`() {
+        val doc = OrgParser.parse("- [x] task\n")
+        val result = OrgMutations.toggleCheckbox(doc, 0, TWO_STATE)!!
+        assertEquals("- [ ] task", result.lines()[0])
+    }
+
+    @Test
+    fun `toggle preserves indent and trailing text`() {
+        val line = checklistDoc.lines.indexOf("  - [ ] nested")
+        val result = OrgMutations.toggleCheckbox(checklistDoc, line, TWO_STATE)!!
+        assertEquals("  - [X] nested", result.lines()[line])
+    }
+
+    @Test
+    fun `toggle only rewrites the target line, everything else is byte-identical`() {
+        val line = checklistDoc.lines.indexOf("- [ ] milk")
+        val result = OrgMutations.toggleCheckbox(checklistDoc, line, TWO_STATE)!!
+        assertEquals(
+            checklistDoc.lines.filterIndexed { i, _ -> i != line },
+            result.lines().filterIndexed { i, _ -> i != line },
+        )
+    }
+
+    @Test
+    fun `non-checkbox list item returns null`() {
+        val line = checklistDoc.lines.indexOf("- plain item")
+        assertNull(OrgMutations.toggleCheckbox(checklistDoc, line, TWO_STATE))
+    }
+
+    @Test
+    fun `non-list line returns null`() {
+        val line = checklistDoc.lines.indexOf("not a list line")
+        assertNull(OrgMutations.toggleCheckbox(checklistDoc, line, TWO_STATE))
+    }
+
+    @Test
+    fun `out of range line index returns null`() {
+        assertNull(OrgMutations.toggleCheckbox(checklistDoc, -1, TWO_STATE))
+        assertNull(OrgMutations.toggleCheckbox(checklistDoc, checklistDoc.lines.size, TWO_STATE))
+    }
 }

--- a/app/src/test/java/com/rrajath/grove/settings/PreferencesTest.kt
+++ b/app/src/test/java/com/rrajath/grove/settings/PreferencesTest.kt
@@ -40,4 +40,19 @@ class PreferencesTest {
         }
         assertEquals(NoteOpenMode.READ, NoteOpenMode.fromStorage(null))
     }
+
+    @Test
+    fun `checklist states round-trips and defaults to two`() {
+        for (pref in ChecklistStates.entries) {
+            assertEquals(pref, ChecklistStates.fromStorage(pref.storageKey))
+        }
+        assertEquals(ChecklistStates.TWO, ChecklistStates.fromStorage(null))
+        assertEquals(ChecklistStates.TWO, ChecklistStates.fromStorage("four"))
+    }
+
+    @Test
+    fun `checklist states marks are ordered open to done`() {
+        assertEquals(listOf(' ', 'X'), ChecklistStates.TWO.marks)
+        assertEquals(listOf(' ', '-', 'X'), ChecklistStates.THREE.marks)
+    }
 }

--- a/app/src/test/java/com/rrajath/grove/settings/SettingsSerializationTest.kt
+++ b/app/src/test/java/com/rrajath/grove/settings/SettingsSerializationTest.kt
@@ -30,6 +30,7 @@ class SettingsSerializationTest {
         pinnedNotebooks = listOf("pinned-first.org", "pinned-second.org"),
         showHeaderTags = false,
         showPropertyDrawers = false,
+        checklistStates = ChecklistStates.THREE,
         // Device-specific fields that must NOT travel with an export.
         vaultTreeUri = "content://com.android.externalstorage/tree/primary%3Aorg",
         onboardingDone = true,
@@ -62,6 +63,7 @@ class SettingsSerializationTest {
         assertEquals(sample.pinnedNotebooks, restored.pinnedNotebooks)
         assertEquals(sample.showHeaderTags, restored.showHeaderTags)
         assertEquals(sample.showPropertyDrawers, restored.showPropertyDrawers)
+        assertEquals(sample.checklistStates, restored.checklistStates)
     }
 
     @Test
@@ -87,12 +89,13 @@ class SettingsSerializationTest {
 
     @Test
     fun `unknown enum values fall back to defaults on import`() {
-        val json = """{ "theme": "sepia", "fontSize": "huge", "syncMode": "warp" }"""
+        val json = """{ "theme": "sepia", "fontSize": "huge", "syncMode": "warp", "checklistStates": "four" }"""
         val restored = SettingsSerialization.import(json, GroveSettings())
 
         assertEquals(ThemePreference.LIGHT, restored.theme)
         assertEquals(FontSizePreference.MEDIUM, restored.fontSize)
         assertEquals(SyncMode.ON_OPEN_CLOSE, restored.syncMode)
+        assertEquals(ChecklistStates.TWO, restored.checklistStates)
     }
 
     @Test


### PR DESCRIPTION
Typing "- [ ] " (or "1. [ ] ") now behaves like other list items: Enter
continues the checklist with a fresh unchecked box, an empty item is
removed on Enter, and the toolbar indent/outdent buttons preserve the
checkbox marker.

In read mode, checklist items render as a tappable checkbox (☐/◧/☑).
Tapping cycles the item's state and persists the change to disk. A new
Settings > Checklist states control lets users choose between two states
(open/done) or three (open/in-progress/done); the default is two-state.
Completed items render greyed out.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016GRys73rTpm7Rzrm6pVnWa