### PR TITLE
Improve outline expand/collapse icon, settings UX, and editor scroll jitter

### DIFF
--- a/app/src/main/java/com/rrajath/grove/ui/components/ScrollJumpButtons.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/components/ScrollJumpButtons.kt
@@ -41,10 +41,13 @@ import kotlinx.coroutines.launch
  * Visibility behavior:
  * - The pair is hidden entirely when the underlying content has no
  *   scrollable overflow (content fits on screen).
- * - The pair appears as soon as any scroll activity happens (a position
- *   change), and disappears again after 3 seconds of scroll inactivity.
- *   Scrolling again at any point makes it reappear immediately and resets
- *   the idle timer.
+ * - The pair appears once scroll activity moves the position by more than
+ *   [minScrollDeltaPx] pixels (from wherever it last settled), and
+ *   disappears again after 3 seconds of scroll inactivity. Scrolling again
+ *   at any point while visible keeps it up and resets the idle timer. The
+ *   threshold exists so that the small scroll nudges caused by the cursor
+ *   auto-following typed text (e.g. in an editor) don't repeatedly flash
+ *   the buttons — only a deliberate scroll of real distance does.
  * - Each button additionally hides itself once already at that edge (the
  *   top button disappears at the top, the bottom button disappears at the
  *   bottom), even while the pair is otherwise visible.
@@ -57,9 +60,10 @@ import kotlinx.coroutines.launch
 fun ScrollJumpButtons(
     scrollState: ScrollState,
     modifier: Modifier = Modifier,
+    minScrollDeltaPx: Float = 0f,
 ) {
     val hasOverflow = scrollState.maxValue > 0
-    val visible = rememberScrollActivityVisible(scrollState.value)
+    val visible = rememberScrollOffsetActivityVisible(scrollState.value, minScrollDeltaPx)
     val atTop = scrollState.value <= 0
     val atBottom = scrollState.value >= scrollState.maxValue
     val scope = rememberCoroutineScope()
@@ -121,6 +125,37 @@ private fun <T> rememberScrollActivityVisible(positionKey: T): Boolean {
         previous = positionKey
         delay(3000)
         visible = false
+    }
+
+    return visible
+}
+
+/**
+ * Like [rememberScrollActivityVisible], but only flips to visible once
+ * [offsetPx] has drifted more than [minDeltaPx] away from wherever it last
+ * settled — small back-and-forth jitter (e.g. the cursor-follow scroll while
+ * typing) never crosses that threshold, so it doesn't flash the buttons.
+ * Once visible, any further movement keeps it up and resets the idle timer,
+ * same as the plain scroll-activity tracker; the baseline resets to the
+ * current offset each time it goes idle again.
+ */
+@Composable
+private fun rememberScrollOffsetActivityVisible(offsetPx: Int, minDeltaPx: Float): Boolean {
+    var visible by remember { mutableStateOf(false) }
+    var baseline by remember { mutableStateOf<Int?>(null) }
+
+    LaunchedEffect(offsetPx) {
+        val base = baseline
+        if (base == null) {
+            baseline = offsetPx
+        } else if (!visible && kotlin.math.abs(offsetPx - base) > minDeltaPx) {
+            visible = true
+        }
+        if (visible) {
+            delay(3000)
+            visible = false
+            baseline = offsetPx
+        }
     }
 
     return visible

--- a/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
@@ -198,6 +198,9 @@ fun EditNoteScreen(
     }
 
     val scrollState = rememberScrollState()
+    // Two lines of editor text (13.5sp font * 1.85 line height), so the jump
+    // buttons don't flash on every keystroke as typing nudges the view.
+    val scrollButtonThresholdPx = with(LocalDensity.current) { (13.5f * 1.85f * 2).sp.toPx() }
 
     Scaffold(
         containerColor = c.bg,
@@ -317,6 +320,7 @@ fun EditNoteScreen(
                 }
                 ScrollJumpButtons(
                     scrollState = scrollState,
+                    minScrollDeltaPx = scrollButtonThresholdPx,
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
                         .padding(16.dp),

--- a/app/src/main/java/com/rrajath/grove/ui/screens/OutlineScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/OutlineScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.material.icons.filled.FormatIndentDecrease
 import androidx.compose.material.icons.filled.FormatIndentIncrease
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.UnfoldLess
+import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -190,12 +192,25 @@ fun OutlineScreen(
                                     .toSet()
                             }
                             if (foldable.isNotEmpty()) {
-                                // Mirrors the per-row carets: ▸▸ = all folded (tap to
-                                // expand all), ▾▾ = expanded (tap to collapse all).
+                                // Chevrons pointing apart = all folded (tap to expand
+                                // all); chevrons pointing together = expanded (tap to
+                                // collapse all).
                                 val allCollapsed = collapsed.containsAll(foldable)
-                                IconGlyph(if (allCollapsed) "▸▸" else "▾▾", onClick = {
-                                    collapsed = if (allCollapsed) emptySet() else foldable
-                                })
+                                Box(
+                                    Modifier
+                                        .size(44.dp)
+                                        .clip(RoundedCornerShape(10.dp))
+                                        .clickable {
+                                            collapsed = if (allCollapsed) emptySet() else foldable
+                                        },
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Icon(
+                                        if (allCollapsed) Icons.Default.UnfoldMore else Icons.Default.UnfoldLess,
+                                        contentDescription = if (allCollapsed) "Expand all headings" else "Collapse all headings",
+                                        tint = c.ink,
+                                    )
+                                }
                             }
                         }
                         var displayMenuOpen by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/rrajath/grove/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/SettingsScreen.kt
@@ -193,19 +193,15 @@ fun SettingsScreen(
                     )
                 }
                 RowDivider()
-                val modeLabel = if (settings.defaultNoteOpenMode == NoteOpenMode.READ) "Read" else "Edit"
                 SettingsRow(
                     label = "Default note mode",
-                    onClick = {
-                        onSetNoteOpenMode(
-                            if (settings.defaultNoteOpenMode == NoteOpenMode.READ) NoteOpenMode.EDIT
-                            else NoteOpenMode.READ
-                        )
-                    },
+                    description = "Open a note in read mode, or edit mode",
                 ) {
-                    Text(
-                        "$modeLabel ›",
-                        fontFamily = PlexSans, fontSize = 14.sp, color = c.ink2,
+                    SegmentedControl(
+                        options = listOf("Read", "Edit"),
+                        selectedIndex = settings.defaultNoteOpenMode.ordinal,
+                        onSelect = { onSetNoteOpenMode(NoteOpenMode.entries[it]) },
+                        modifier = Modifier.width(160.dp),
                     )
                 }
             }
@@ -339,7 +335,10 @@ fun SettingsScreen(
                     )
                 }
                 RowDivider()
-                SettingsRow(label = "Notebook display name") {
+                SettingsRow(
+                    label = "Notebook display name",
+                    description = "Filename: shown by filename. Title: shown by title, falling back to filename.",
+                ) {
                     SegmentedControl(
                         options = listOf("Filename", "Title"),
                         selectedIndex = settings.notebookDisplayNameMode.ordinal,
@@ -348,7 +347,10 @@ fun SettingsScreen(
                     )
                 }
                 RowDivider()
-                SettingsRow(label = "Checklist states") {
+                SettingsRow(
+                    label = "Checklist states",
+                    description = "2-state: [ ] → [x]. 3-state: [ ] → [-] → [x].",
+                ) {
                     SegmentedControl(
                         options = listOf("2-state", "3-state"),
                         selectedIndex = settings.checklistStates.ordinal,
@@ -359,12 +361,14 @@ fun SettingsScreen(
                 RowDivider()
                 ToggleRow(
                     label = "Add ID to new notes",
+                    description = "Adds an ID property to the property drawer when creating new notes",
                     checked = settings.addIdToNewNotes,
                     onToggle = onSetAddId,
                 )
                 RowDivider()
                 ToggleRow(
                     label = "Add CREATED timestamp",
+                    description = "Adds a CREATED property with the current timestamp when creating new notes",
                     checked = settings.addCreatedToNewNotes,
                     onToggle = onSetAddCreated,
                 )
@@ -470,6 +474,7 @@ private fun RowDivider() {
 @Composable
 private fun SettingsRow(
     label: String,
+    description: String? = null,
     onClick: (() -> Unit)? = null,
     trailing: @Composable () -> Unit,
 ) {
@@ -481,12 +486,20 @@ private fun SettingsRow(
             .padding(horizontal = 15.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            label,
-            fontFamily = PlexSans, fontWeight = FontWeight.Medium,
-            fontSize = 14.5.sp, color = MaterialTheme.grove.ink,
-            modifier = Modifier.weight(1f),
-        )
+        Column(Modifier.weight(1f)) {
+            Text(
+                label,
+                fontFamily = PlexSans, fontWeight = FontWeight.Medium,
+                fontSize = 14.5.sp, color = MaterialTheme.grove.ink,
+            )
+            if (description != null) {
+                Text(
+                    description,
+                    fontFamily = PlexSans, fontSize = 12.sp, color = MaterialTheme.grove.ink2,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+        }
         trailing()
     }
 }


### PR DESCRIPTION
- Replace text-glyph expand/collapse-all button in outline with
  UnfoldMore/UnfoldLess chevron icons that reflect collapsed/expanded state
- Convert "Default note mode" setting to a segmented control, matching the
  UX of other 2/3-state settings like checklist states
- Add help text under Created timestamp, checklist states, notebook
  display name, add-ID, and default-note-mode settings
- Gate the edit-mode scroll jump buttons behind a ~2-line scroll threshold
  so they don't flash on every keystroke as typing nudges the view