### PR TITLE
Fix reminder notification tap, keyboard gap, and agenda snippet overflow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.Grove">
+            android:theme="@style/Theme.Grove"
+            android:windowSoftInputMode="adjustResize">
             <!-- Share sheet target: text and URLs route into capture (PRD §10) -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/java/com/rrajath/grove/reminders/ReminderNotification.kt
+++ b/app/src/main/java/com/rrajath/grove/reminders/ReminderNotification.kt
@@ -32,7 +32,7 @@ object ReminderNotification {
 
         val contentIntent = PendingIntent.getActivity(
             context, reminder.notificationId,
-            context.packageManager.getLaunchIntentForPackage(context.packageName) ?: Intent(),
+            Intent(Intent.ACTION_VIEW, contentUri(reminder)).setClass(context, MainActivity::class.java),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
@@ -84,4 +84,16 @@ object ReminderNotification {
                 "&level=${reminder.headingLevel}" +
                 "&type=${reminder.planningType}" +
                 "&notifId=${reminder.notificationId}").toUri()
+
+    /**
+     * Tapping the notification body (as opposed to its "Reschedule" action)
+     * should just land on the due heading, not auto-open [PlanningDatePicker] —
+     * an empty `type` makes `ReminderResolveScreen` resolve the same heading
+     * while `GroveApp`'s `takeIf { isNotBlank() }` drops the blank planning arg.
+     */
+    private fun contentUri(reminder: ReminderEntity): android.net.Uri =
+        ("grove://reminder/${Routes.encode(reminder.fileName)}" +
+                "?headingPath=${Routes.encode(reminder.headingPath)}" +
+                "&level=${reminder.headingLevel}" +
+                "&type=").toUri()
 }

--- a/app/src/main/java/com/rrajath/grove/ui/agenda/AgendaScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/agenda/AgendaScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
@@ -194,6 +195,7 @@ private fun AgendaResultRow(result: AgendaResult, onOpenNote: (NoteRef) -> Unit)
             Text(
                 result.snippet.text,
                 fontFamily = PlexSans, fontSize = 13.5.sp, lineHeight = 1.5.em, color = c.ink2,
+                maxLines = 2, overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(top = 3.dp),
             )
         }


### PR DESCRIPTION
- Reminder notifications launched a bare launcher intent instead of a
  grove:// deep link, so tapping one always opened the home screen.
  Point it at the same reminder-resolve flow the Reschedule action
  uses, with an empty planning type so it lands on the task without
  auto-opening the date picker.
- MainActivity had no windowSoftInputMode declared, so the legacy
  system pan adjustment ran alongside Compose's own ime-inset padding
  in EditNoteScreen, double-compensating and leaving a gap between the
  toolbar and the keyboard until the next layout pass. adjustResize
  leaves IME handling entirely to Compose's insets.
- Agenda result snippets rendered unbounded; cap at 2 lines with an
  ellipsis to match SearchResultRow's snippet.