### PR TITLE
Outline search + state picker, agenda done filter, autosave fixes

### DIFF
--- a/app/src/main/java/com/rrajath/grove/search/QueryMatcher.kt
+++ b/app/src/main/java/com/rrajath/grove/search/QueryMatcher.kt
@@ -139,11 +139,15 @@ object QueryMatcher {
      * `ad.N`: each note appears under every day in [today, today+N) where it is
      * scheduled or due. Overdue items get their own section instead of being
      * folded into today's bucket, so both sections can be sorted independently.
+     *
+     * Both sections are outstanding work only — a note whose keyword is a
+     * done-type one is finished, so it drops out of the agenda entirely rather
+     * than lingering under its planning date.
      */
     fun agenda(notes: List<NoteMeta>, days: Int, today: LocalDate): Agenda {
-        val overdue = notes.filter { note ->
-            !note.isDoneKeyword &&
-                listOfNotNull(note.scheduledDate, note.deadlineDate).any { it.isBefore(today) }
+        val open = notes.filter { !it.isDoneKeyword }
+        val overdue = open.filter { note ->
+            listOfNotNull(note.scheduledDate, note.deadlineDate).any { it.isBefore(today) }
         }.sortedWith(
             compareBy<NoteMeta> { note ->
                 listOfNotNull(note.scheduledDate, note.deadlineDate).filter { it.isBefore(today) }.min()
@@ -152,7 +156,7 @@ object QueryMatcher {
 
         val range = (0 until days.coerceAtLeast(1)).map { today.plusDays(it.toLong()) }
         val dayEntries = range.mapNotNull { day ->
-            val dayNotes = notes.filter { note ->
+            val dayNotes = open.filter { note ->
                 listOfNotNull(note.scheduledDate, note.deadlineDate).any { it == day }
             }.sortedWith(
                 compareBy<NoteMeta> { it.priority ?: "Z" }

--- a/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
@@ -202,6 +202,7 @@ private fun GroveNavigation(
                     },
                     // A freshly created note opens straight in edit mode (blank heading).
                     onCreateNote = { ref -> navController.navigate(Routes.note(ref.encode(), "edit", isNew = true)) },
+                    onSearchInNotebook = { navController.navigate(Routes.search(notebook = notebookId)) },
                     // Toggle: the outline's ★ swipe action both adds and removes.
                     onFavorite = { fileName, lineIndex, title ->
                         if (favorites.any { it.fileName == fileName && it.lineIndex == lineIndex }) {
@@ -344,6 +345,7 @@ private fun GroveNavigation(
             composable(Routes.SEARCH) { entry ->
                 SearchScreen(
                     initialQuery = entry.arguments?.getString("q"),
+                    initialNotebook = entry.arguments?.getString("notebook"),
                     onBack = { navController.popBackStack() },
                     onOpenNote = { ref -> navController.navigate(Routes.note(ref.encode())) },
                 )

--- a/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/capture/CaptureEditorScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -167,22 +167,22 @@ fun CaptureEditorScreen(
     var showDiscardDialog by remember { mutableStateOf(false) }
     var showEmptyHeadingAlert by remember { mutableStateOf(false) }
 
-    // Mirrors the note editor's auto-save indicator: a tappable check mark
-    // in the top bar once the draft has been auto-saved at least once.
+    // Mirrors the note editor's auto-save indicator: a tappable save (floppy)
+    // icon in the top bar once the draft has been auto-saved at least once.
     var lastAutoSavedAt by remember { mutableStateOf<LocalTime?>(null) }
-    // Text as of the last auto-save, so the check mark can tell whether the
+    // Text as of the last auto-save, so the save icon can tell whether the
     // draft has drifted since then (grey) or still matches disk (green).
     var lastAutoSavedText by remember(expanded) { mutableStateOf(initialText) }
-    // Blinks the check mark twice on each auto-save instead of a toast;
-    // tapping the check mark still shows a "saved at" toast on demand.
-    val checkAlpha = remember { Animatable(1f) }
+    // Blinks the save icon twice on each auto-save instead of a toast;
+    // tapping the icon still shows a "saved at" toast on demand.
+    val saveIconAlpha = remember { Animatable(1f) }
     val toastContext = LocalContext.current
 
     LaunchedEffect(lastAutoSavedAt) {
         if (lastAutoSavedAt == null) return@LaunchedEffect
         repeat(2) {
-            checkAlpha.animateTo(0.15f, tween(120))
-            checkAlpha.animateTo(1f, tween(120))
+            saveIconAlpha.animateTo(0.15f, tween(120))
+            saveIconAlpha.animateTo(1f, tween(120))
         }
     }
 
@@ -233,14 +233,14 @@ fun CaptureEditorScreen(
                     }
                     lastAutoSavedAt?.let { savedAt ->
                         Icon(
-                            Icons.Default.Check,
+                            Icons.Outlined.Save,
                             contentDescription = "Auto saved",
                             // Green while the draft matches what's on disk (and
                             // blinks right after a save); grey again the moment a
                             // keystroke makes it dirty, until the next auto-save.
                             tint = if (draftText != lastAutoSavedText) c.ink3 else c.green,
                             modifier = Modifier
-                                .alpha(checkAlpha.value)
+                                .alpha(saveIconAlpha.value)
                                 .clip(RoundedCornerShape(10.dp))
                                 .clickable {
                                     val formatted = AutoSaveTimestamp.format(savedAt)

--- a/app/src/main/java/com/rrajath/grove/ui/capture/CaptureViewModel.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/capture/CaptureViewModel.kt
@@ -9,6 +9,7 @@ import com.rrajath.grove.capture.CaptureContext
 import com.rrajath.grove.capture.CaptureInserter
 import com.rrajath.grove.capture.CaptureTemplate
 import com.rrajath.grove.capture.TemplatesRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +17,9 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 
 sealed class SaveState {
@@ -39,6 +43,12 @@ class CaptureViewModel(private val app: GroveApplication) : ViewModel() {
     // final Save replaces it in place instead of inserting a duplicate copy.
     private var draftInsertion: CaptureInserter.Insertion? = null
 
+    // Draft writes are read-modify-write over the whole target file and are
+    // triggered from two places (the 5s idle autosave and the Save button), so
+    // they must not interleave — the loser would re-insert against a stale
+    // `draftInsertion` and leave a duplicate entry behind.
+    private val writeMutex = Mutex()
+
     /**
      * Insert [entryText] into the template's target file, creating the file
      * if it doesn't exist yet.
@@ -51,7 +61,7 @@ class CaptureViewModel(private val app: GroveApplication) : ViewModel() {
         _saveState.value = SaveState.Saving
         viewModelScope.launch {
             try {
-                upsertEntry(template, entryText, context)
+                writeMutex.withLock { upsertEntry(template, entryText, context) }
                 app.syncManager.requestSync("capture saved")
                 draftInsertion = null
                 _saveState.value = SaveState.Saved
@@ -70,7 +80,7 @@ class CaptureViewModel(private val app: GroveApplication) : ViewModel() {
         if (entryText.isBlank()) return
         viewModelScope.launch {
             try {
-                upsertEntry(template, entryText, context)
+                writeMutex.withLock { upsertEntry(template, entryText, context) }
             } catch (_: Exception) {
                 // Best-effort: a failed autosave just waits for the next tick
                 // or the explicit Save tap, which surfaces errors to the user.
@@ -83,9 +93,12 @@ class CaptureViewModel(private val app: GroveApplication) : ViewModel() {
         val prev = draftInsertion ?: return
         draftInsertion = null
         viewModelScope.launch {
-            val vault = app.vault.value ?: return@launch
-            val text = vault.open(template.targetFile)?.text ?: return@launch
-            vault.save(template.targetFile, CaptureInserter.removeInsertion(text, prev))
+            writeMutex.withLock {
+                val vault = app.vault.value ?: return@withLock
+                val text = withContext(Dispatchers.Default) { vault.open(template.targetFile)?.text }
+                    ?: return@withLock
+                vault.save(template.targetFile, CaptureInserter.removeInsertion(text, prev))
+            }
             app.syncManager.requestSync("capture discarded")
         }
     }
@@ -99,19 +112,26 @@ class CaptureViewModel(private val app: GroveApplication) : ViewModel() {
         // On a cold start (e.g. launched via app shortcut) the vault may
         // still be initializing even though a folder is configured; await it.
         val vault = app.vault.filterNotNull().first()
-        if (vault.open(template.targetFile) == null) {
-            vault.createNotebook(template.targetFile)
+        // Parsing the target file and splicing the entry into it are pure CPU
+        // over the whole document. The idle autosave fires while the user is
+        // still typing, so this stays off the main thread — a parse stall there
+        // desynchronizes the IME from the text field and swallows keystrokes.
+        val result = withContext(Dispatchers.Default) {
+            if (vault.open(template.targetFile) == null) {
+                vault.createNotebook(template.targetFile)
+            }
+            val currentText = vault.open(template.targetFile)?.text ?: ""
+            // Strip our own previous draft first so re-inserting replaces it in
+            // place rather than leaving a stale duplicate behind.
+            val baseText = draftInsertion?.let { CaptureInserter.removeInsertion(currentText, it) }
+                ?: currentText
+            CaptureInserter.insert(
+                docText = baseText,
+                location = template.location,
+                entry = entryText,
+                today = LocalDate.from(context.now),
+            )
         }
-        val currentText = vault.open(template.targetFile)?.text ?: ""
-        // Strip our own previous draft first so re-inserting replaces it in
-        // place rather than leaving a stale duplicate behind.
-        val baseText = draftInsertion?.let { CaptureInserter.removeInsertion(currentText, it) } ?: currentText
-        val result = CaptureInserter.insert(
-            docText = baseText,
-            location = template.location,
-            entry = entryText,
-            today = LocalDate.from(context.now),
-        )
         vault.save(template.targetFile, result.newText)
         draftInsertion = result
     }

--- a/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/EditNoteScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -105,18 +105,16 @@ fun EditNoteScreen(
     var confirmLeave by remember { mutableStateOf(false) }
     var showEmptyHeadingAlert by remember { mutableStateOf(false) }
     var rescheduleTarget by remember(openPlanningTarget) { mutableStateOf(openPlanningTarget) }
-    // Timestamp of the most recent auto-save, shown as a tappable check mark
-    // in the top bar once the note has been saved at least once.
+    // Timestamp of the most recent auto-save, shown as a tappable save (floppy)
+    // icon in the top bar once the note has been saved at least once.
     var lastAutoSavedAt by remember { mutableStateOf<LocalTime?>(null) }
-    // Blinks the check mark twice on each auto-save instead of a toast; tapping
-    // the check mark still shows the "saved at" toast on demand.
-    val checkAlpha = remember { Animatable(1f) }
+    // Blinks the save icon twice on each auto-save instead of a toast; tapping
+    // the icon still shows the "saved at" toast on demand.
+    val saveIconAlpha = remember { Animatable(1f) }
     val focusRequester = remember { FocusRequester() }
-    // Tracks the buffer the text field already reflects, so the
-    // external-mutation sync effect below doesn't clobber the deliberate
-    // divergence (appended blank body line) set for a fresh FAB-created note.
-    // Null until the note has been loaded into the field.
-    var syncedBuffer by remember { mutableStateOf<String?>(null) }
+    // False until the note has been loaded into the text field: the field's
+    // pre-load contents are not the user's edits and must not be reported.
+    var fieldLoaded by remember { mutableStateOf(false) }
     // Text last written into the field programmatically (initial load, metadata
     // sheet rewrite). The snapshotFlow below echoes every write straight back;
     // that echo must not be reported as a user edit, which would wrongly mark a
@@ -169,22 +167,27 @@ fun EditNoteScreen(
                 )
                 setText(state.buffer, TextRange(cursor))
             }
-            syncedBuffer = state.buffer
+            fieldLoaded = true
             if (isNewNote) focusRequester.requestFocus()
         }
     }
-    // Metadata-sheet mutations rewrite the buffer outside the text field.
-    LaunchedEffect(state.buffer) {
-        if (state.buffer != syncedBuffer && state.buffer != textState.text.toString()) {
-            setText(state.buffer, TextRange(textState.selection.start.coerceAtMost(state.buffer.length)))
+    // Metadata-sheet mutations rewrite the buffer outside the text field. Keyed
+    // on the view model's explicit revision counter, never on the buffer text:
+    // the field reports its edits one frame behind, so a text comparison could
+    // see the *previous* buffer alongside the newest field contents and push
+    // the older text back in, eating the characters typed in between.
+    LaunchedEffect(state.bufferRevision) {
+        if (!fieldLoaded || state.bufferRevision == 0L) return@LaunchedEffect
+        val buffer = state.buffer
+        if (buffer != textState.text.toString()) {
+            setText(buffer, TextRange(textState.selection.start.coerceAtMost(buffer.length)))
         }
-        syncedBuffer = state.buffer
     }
     // Report the user's own edits back to the view model. Programmatic writes
     // (setText above) are filtered out, so only real typing marks the note dirty.
     LaunchedEffect(Unit) {
         snapshotFlow { textState.text.toString() }.collect { text ->
-            if (syncedBuffer == null) return@collect
+            if (!fieldLoaded) return@collect
             if (text == echoToSkip) {
                 echoToSkip = null
                 return@collect
@@ -207,12 +210,12 @@ fun EditNoteScreen(
         }
     }
 
-    // Blink the check mark twice in quick succession on each auto-save.
+    // Blink the save icon twice in quick succession on each auto-save.
     LaunchedEffect(lastAutoSavedAt) {
         if (lastAutoSavedAt == null) return@LaunchedEffect
         repeat(2) {
-            checkAlpha.animateTo(0.15f, tween(120))
-            checkAlpha.animateTo(1f, tween(120))
+            saveIconAlpha.animateTo(0.15f, tween(120))
+            saveIconAlpha.animateTo(1f, tween(120))
         }
     }
 
@@ -233,14 +236,14 @@ fun EditNoteScreen(
                     IconGlyph("←", onClick = ::leave)
                     lastAutoSavedAt?.let { savedAt ->
                         Icon(
-                            Icons.Default.Check,
+                            Icons.Outlined.Save,
                             contentDescription = "Auto saved",
                             // Green while the buffer matches what's on disk (and
                             // blinks right after a save); grey again the moment a
                             // keystroke makes it dirty, until the next auto-save.
                             tint = if (state.dirty) c.ink3 else c.green,
                             modifier = Modifier
-                                .alpha(checkAlpha.value)
+                                .alpha(saveIconAlpha.value)
                                 .clip(RoundedCornerShape(10.dp))
                                 .clickable {
                                     val formatted = AutoSaveTimestamp.format(savedAt)

--- a/app/src/main/java/com/rrajath/grove/ui/editor/EditorViewModel.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/editor/EditorViewModel.kt
@@ -11,9 +11,14 @@ import com.rrajath.grove.org.OrgParser
 import com.rrajath.grove.org.OrgTimestamp
 import com.rrajath.grove.ui.vault.NoteRef
 import com.rrajath.grove.ui.vault.factory
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.time.LocalDateTime
 
 data class EditorUiState(
@@ -29,6 +34,15 @@ data class EditorUiState(
     /** File changed on disk since load; offer overwrite (Force Save). */
     val staleFile: Boolean = false,
     val allTags: List<String> = emptyList(),
+    /**
+     * Counts buffer rewrites that did *not* come from the text field — today
+     * only the metadata sheet's mutations. The editor screen pushes the buffer
+     * into the field when this changes, and never otherwise: inferring
+     * "external rewrite" from the buffer text alone made fast typing race the
+     * one-frame lag of the field→view-model report, and re-pushing the older
+     * buffer swallowed the characters typed in between. Reset to 0 by [load].
+     */
+    val bufferRevision: Long = 0,
 )
 
 class EditorViewModel(private val app: GroveApplication) : ViewModel() {
@@ -36,7 +50,14 @@ class EditorViewModel(private val app: GroveApplication) : ViewModel() {
     private val _state = MutableStateFlow(EditorUiState())
     val state: StateFlow<EditorUiState> = _state
 
+    /** Serializes writes so an idle auto-save and an explicit save can't race. */
+    private val saveMutex = Mutex()
+
     fun load(ref: NoteRef) {
+        // Republished as loading first so a re-load (the stale-file banner's
+        // "Reload") is a visible false→true→false transition — that edge is what
+        // makes the editor screen re-seed its text field from the fresh buffer.
+        _state.update { it.copy(loading = true, error = null) }
         viewModelScope.launch {
             val vault = app.vault.value ?: run {
                 _state.value = EditorUiState(loading = false, error = "No sync folder configured")
@@ -67,8 +88,9 @@ class EditorViewModel(private val app: GroveApplication) : ViewModel() {
         }
     }
 
+    /** The text field reporting the user's own typing — never echoed back to it. */
     fun onBufferChange(text: String) {
-        _state.value = _state.value.copy(buffer = text, dirty = true)
+        _state.update { it.copy(buffer = text, dirty = true) }
     }
 
     // Memoize the most recent parse so repeated currentHeadline reads and the
@@ -93,9 +115,13 @@ class EditorViewModel(private val app: GroveApplication) : ViewModel() {
     val currentHeadline: OrgHeadline?
         get() = bufferHeadline()?.second
 
+    /** Metadata-sheet edits: rewrite the buffer outside the text field, and bump
+     *  [EditorUiState.bufferRevision] so the screen mirrors it into the field. */
     private fun mutateBuffer(block: (OrgDocument, OrgHeadline) -> String) {
         val (doc, h) = bufferHeadline() ?: return
-        _state.value = _state.value.copy(buffer = block(doc, h), dirty = true)
+        _state.update {
+            it.copy(buffer = block(doc, h), dirty = true, bufferRevision = it.bufferRevision + 1)
+        }
     }
 
     fun setKeyword(keyword: String?) = mutateBuffer { d, h -> OrgMutations.setKeyword(d, h, keyword) }
@@ -112,42 +138,79 @@ class EditorViewModel(private val app: GroveApplication) : ViewModel() {
     /**
      * Write the buffer back into the file. Refuses (sets [EditorUiState.staleFile])
      * if the file changed on disk since load, unless [force].
+     *
+     * A save runs concurrently with typing (idle auto-save fires on a timer, and
+     * the write itself is slow SAF I/O), so it must never publish a snapshot of
+     * the state it captured when it started — doing so would rewind the buffer
+     * to the pre-save text and drop whatever was typed in between. Every write
+     * back into [_state] therefore goes through `update`, touching only the
+     * fields this save actually owns, and [dirty] is recomputed by comparing the
+     * text that reached disk against the text the buffer holds *now*.
      */
     fun save(force: Boolean = false, onSaved: () -> Unit = {}) {
-        val s = _state.value
-        if (!s.dirty || s.error != null) {
+        val initial = _state.value
+        if (!initial.dirty || initial.error != null) {
             onSaved()
             return
         }
         viewModelScope.launch {
-            val vault = app.vault.value ?: return@launch
-            val currentRevision = vault.revision(s.fileName)
-            if (!force && currentRevision != s.loadedRevision) {
-                _state.value = s.copy(staleFile = true)
-                return@launch
-            }
-            val doc = vault.open(s.fileName) ?: return@launch
-            val headline = doc.headlines.firstOrNull { it.lineIndex == s.lineIndex }
-            val newText = if (headline != null) {
-                OrgMutations.replaceSubtree(doc, headline, s.buffer)
-            } else {
-                // Note vanished from the file (heavy external edit) — append the
-                // buffer at the end rather than lose the user's work.
-                doc.text.trimEnd('\n') + "\n" + s.buffer.trimEnd('\n') + "\n"
-            }
-            vault.save(s.fileName, newText)
-            app.syncManager.requestSync("note saved")
-            _state.value = s.copy(
-                dirty = false,
-                staleFile = false,
-                loadedRevision = vault.revision(s.fileName),
-            )
-            onSaved()
+            // Serialized: two overlapping saves would both compute a new file
+            // text from the same on-disk revision, and the slower one would
+            // silently undo the faster one.
+            val saved = saveMutex.withLock { writeBuffer(force) }
+            if (saved) onSaved()
         }
     }
 
+    /** @return true when the buffer is on disk (including "already was"). */
+    private suspend fun writeBuffer(force: Boolean): Boolean {
+        val s = _state.value
+        if (s.error != null) return false
+        // Another save (e.g. the idle auto-save that fired while the leave
+        // dialog was up) got there first — the caller's "then leave" follow-up
+        // is still owed.
+        if (!s.dirty) return true
+        val vault = app.vault.value ?: return false
+        // The exact text this save is responsible for. Anything typed after
+        // this line belongs to the next save, not this one.
+        val savedBuffer = s.buffer
+        val currentRevision = vault.revision(s.fileName)
+        if (!force && currentRevision != s.loadedRevision) {
+            _state.update { it.copy(staleFile = true) }
+            return false
+        }
+        // Parsing and the subtree splice are pure CPU on a whole file; keep them
+        // off the main thread so a large notebook can't stall the keyboard
+        // mid-keystroke while an auto-save runs.
+        val newText = withContext(Dispatchers.Default) {
+            val doc = vault.open(s.fileName) ?: return@withContext null
+            val headline = doc.headlines.firstOrNull { it.lineIndex == s.lineIndex }
+            if (headline != null) {
+                OrgMutations.replaceSubtree(doc, headline, savedBuffer)
+            } else {
+                // Note vanished from the file (heavy external edit) — append the
+                // buffer at the end rather than lose the user's work.
+                doc.text.trimEnd('\n') + "\n" + savedBuffer.trimEnd('\n') + "\n"
+            }
+        } ?: return false
+        vault.save(s.fileName, newText)
+        val newRevision = vault.revision(s.fileName)
+        app.syncManager.requestSync("note saved")
+        _state.update { current ->
+            current.copy(
+                // Still dirty if the user typed while the write was in flight —
+                // those characters are only in memory, and the idle timer (keyed
+                // on the buffer) will have already re-armed for them.
+                dirty = current.buffer != savedBuffer,
+                staleFile = false,
+                loadedRevision = newRevision,
+            )
+        }
+        return true
+    }
+
     fun dismissStale() {
-        _state.value = _state.value.copy(staleFile = false)
+        _state.update { it.copy(staleFile = false) }
     }
 
     fun isCurrentHeadingBlank(): Boolean = currentHeadline?.title.isNullOrBlank()

--- a/app/src/main/java/com/rrajath/grove/ui/nav/Routes.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/nav/Routes.kt
@@ -13,7 +13,7 @@ object Routes {
     const val NOTE = "note/{noteId}?mode={mode}&isNew={isNew}&planning={planning}&notifId={notifId}"
     const val CAPTURE = "capture"
     const val CAPTURE_TEMPLATE = "capture/{templateId}"
-    const val SEARCH = "search?q={q}"
+    const val SEARCH = "search?q={q}&notebook={notebook}"
     const val AGENDA = "agenda"
     const val CONFLICT = "conflict/{notebookId}"
     const val SETTINGS = "settings"
@@ -60,8 +60,15 @@ object Routes {
         if (templateId == null) CAPTURE else "capture/${encode(templateId)}"
     fun conflict(notebookId: String) = "conflict/${encode(notebookId)}"
     fun templateEdit(templateId: String) = "template/${encode(templateId)}"
-    fun search(query: String? = null) =
-        if (query.isNullOrBlank()) "search?q=" else "search?q=${encode(query)}"
+    /**
+     * [notebook] pins the search's notebook facet to one file — used by the
+     * Outline's search action, which searches inside the notebook you're
+     * already looking at. The user can still widen it back to all notebooks
+     * from the Filters sheet.
+     */
+    fun search(query: String? = null, notebook: String? = null) =
+        "search?q=" + (if (query.isNullOrBlank()) "" else encode(query)) +
+                (if (notebook.isNullOrBlank()) "" else "&notebook=${encode(notebook)}")
     fun reminder(fileName: String, headingPath: String, level: Int, type: String, notifId: Int) =
         "reminder/${encode(fileName)}?headingPath=${encode(headingPath)}&level=$level&type=$type&notifId=$notifId"
 }

--- a/app/src/main/java/com/rrajath/grove/ui/screens/OutlineScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/screens/OutlineScreen.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -28,12 +30,14 @@ import androidx.compose.material.icons.filled.FormatIndentDecrease
 import androidx.compose.material.icons.filled.FormatIndentIncrease
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.UnfoldLess
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -63,6 +67,7 @@ import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rrajath.grove.org.OrgDocument
 import com.rrajath.grove.org.OrgHeadline
+import com.rrajath.grove.org.OrgKeywords
 import com.rrajath.grove.org.OrgTimestamp
 import com.rrajath.grove.settings.OutlineToggle
 import com.rrajath.grove.ui.components.CollapsibleKvSection
@@ -109,6 +114,8 @@ fun OutlineScreen(
     narrowLineIndex: Int? = null,
     /** Return to the full, unnarrowed outline. */
     onWiden: () -> Unit = {},
+    /** Top-bar ⌕: opens Search with the notebook filter already pinned to this file. */
+    onSearchInNotebook: () -> Unit = {},
     onFavorite: (fileName: String, lineIndex: Int, title: String) -> Unit = { _, _, _ -> },
     /** Line indices of favorited headlines in this notebook — marked with a ★. */
     favoriteLines: Set<Int> = emptySet(),
@@ -151,6 +158,8 @@ fun OutlineScreen(
     var openRowLine by remember { mutableStateOf<Int?>(null) }
     // Which headline the date-picker dialog targets: lineIndex to "scheduled"/"deadline".
     var datePickerFor by remember { mutableStateOf<Pair<Int, String>?>(null) }
+    // Line index whose TODO state the swipe panel's "State" action is picking.
+    var statePickerFor by remember { mutableStateOf<Int?>(null) }
 
     // The command bar takes over the top bar in focus mode; back exits it.
     BackHandler(enabled = focusedLine != null) { viewModel.setFocus(null) }
@@ -262,6 +271,19 @@ fun OutlineScreen(
                                     )
                                 }
                             }
+                        }
+                        Box(
+                            Modifier
+                                .size(44.dp)
+                                .clip(RoundedCornerShape(10.dp))
+                                .clickable(onClick = onSearchInNotebook),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                Icons.Default.Search,
+                                contentDescription = "Search in this notebook",
+                                tint = c.ink,
+                            )
                         }
                         var displayMenuOpen by remember { mutableStateOf(false) }
                         Box {
@@ -391,7 +413,7 @@ fun OutlineScreen(
                                 // Right-swipe panel: state / schedule / deadline / favorite.
                                 leftActions = listOf(
                                     SwipeAction("⟳", "State", c.amber, c.amberSoft) {
-                                        viewModel.cycleState(h)
+                                        statePickerFor = h.lineIndex
                                     },
                                     SwipeAction("◷", "Sched", c.blue, c.blueSoft) {
                                         datePickerFor = h.lineIndex to "scheduled"
@@ -469,6 +491,21 @@ fun OutlineScreen(
                     }
                 }
 
+                statePickerFor?.let { line ->
+                    doc.headlineAtLine(line)?.let { headline ->
+                        StatePickerSheet(
+                            title = headline.title,
+                            keywords = doc.keywords,
+                            current = headline.keyword,
+                            onPick = { keyword ->
+                                viewModel.setState(headline, keyword)
+                                statePickerFor = null
+                            },
+                            onDismiss = { statePickerFor = null },
+                        )
+                    }
+                }
+
                 datePickerFor?.let { (line, target) ->
                     val headline = doc.headlineAtLine(line)
                     val existing = if (target == "scheduled") headline?.planning?.scheduled
@@ -502,6 +539,81 @@ fun OutlineScreen(
                 }
             }
         }
+    }
+}
+
+/**
+ * TODO-state picker for the outline's right-swipe "State" action. Replaces the
+ * old tap-to-cycle behaviour, which needed one tap per intervening keyword to
+ * reach DONE; every configured state (plus "none") is one tap away here.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun StatePickerSheet(
+    title: String,
+    keywords: OrgKeywords,
+    current: String?,
+    onPick: (String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val c = MaterialTheme.grove
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = c.surface,
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+    ) {
+        Column(Modifier.padding(horizontal = 22.dp).padding(bottom = 30.dp)) {
+            Text(
+                "STATE",
+                fontFamily = PlexSans, fontWeight = FontWeight.SemiBold,
+                fontSize = 12.sp, letterSpacing = 1.sp, color = c.accent,
+            )
+            Text(
+                title,
+                fontFamily = PlexSans, fontSize = 13.5.sp, color = c.ink2,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 4.dp, bottom = 14.dp),
+            )
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                StateChip("none", active = current == null, fg = c.ink2, bg = c.surface2) {
+                    onPick(null)
+                }
+                keywords.all.forEach { kw ->
+                    val done = keywords.isDone(kw)
+                    StateChip(
+                        label = kw,
+                        active = current == kw,
+                        fg = if (done) c.green else c.amber,
+                        bg = if (done) c.greenSoft else c.amberSoft,
+                    ) { onPick(kw) }
+                }
+            }
+        }
+    }
+}
+
+/** Matches the metadata sheet's state chips so both pickers read as one control. */
+@Composable
+private fun StateChip(label: String, active: Boolean, fg: Color, bg: Color, onClick: () -> Unit) {
+    val c = MaterialTheme.grove
+    Box(
+        Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(if (active) bg else c.surface2.copy(alpha = 0.5f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 13.dp, vertical = 9.dp),
+    ) {
+        Text(
+            label,
+            fontFamily = PlexMono,
+            fontWeight = if (active) FontWeight.Bold else FontWeight.Normal,
+            fontSize = 12.sp,
+            color = if (active) fg else c.ink2,
+        )
     }
 }
 

--- a/app/src/main/java/com/rrajath/grove/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/search/SearchScreen.kt
@@ -94,6 +94,13 @@ fun SearchScreen(
     initialQuery: String?,
     onBack: () -> Unit,
     onOpenNote: (NoteRef) -> Unit,
+    /**
+     * Notebook to pin the search to on entry (the Outline's search action passes
+     * the file you were reading). The pin is an ordinary notebook filter from
+     * there on: the Filters sheet can point it at another file or widen it back
+     * to all notebooks, and the "searching in …" note below the field follows.
+     */
+    initialNotebook: String? = null,
     viewModel: SearchViewModel = viewModel(factory = SearchViewModel.Factory),
 ) {
     val c = MaterialTheme.grove
@@ -109,6 +116,9 @@ fun SearchScreen(
     LaunchedEffect(initialQuery) {
         if (!initialQuery.isNullOrBlank()) viewModel.submit(initialQuery)
         else focusRequester.requestFocus()
+    }
+    LaunchedEffect(initialNotebook) {
+        if (!initialNotebook.isNullOrBlank()) viewModel.pinNotebook(initialNotebook)
     }
 
     // First back press (system gesture or the in-screen arrow) clears back to the
@@ -157,6 +167,27 @@ fun SearchScreen(
                 }
                 if (state.query.isNotBlank()) {
                     IconGlyph("☆", onClick = { saveDialogOpen = true })
+                }
+            }
+
+            // Scope note: names the one notebook being searched. Driven by the
+            // live filter (not the entry argument), so retargeting it in the
+            // Filters sheet renames the file here and widening to all notebooks
+            // removes the note entirely.
+            state.filters.notebook?.let { notebook ->
+                Row(
+                    // Indented past the back arrow (10dp gutter + 44dp glyph) so
+                    // the note hangs under the search field, not the whole row.
+                    Modifier.fillMaxWidth().padding(start = 56.dp, end = 14.dp, bottom = 2.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("searching in ", fontFamily = PlexSans, fontSize = 11.5.sp, color = c.ink3)
+                    Text(
+                        notebook,
+                        fontFamily = PlexMono, fontWeight = FontWeight.Medium,
+                        fontSize = 11.5.sp, color = c.ink2,
+                        maxLines = 1, overflow = TextOverflow.Ellipsis,
+                    )
                 }
             }
 

--- a/app/src/main/java/com/rrajath/grove/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/search/SearchViewModel.kt
@@ -212,6 +212,16 @@ class SearchViewModel(private val app: GroveApplication) : ViewModel() {
     fun setNotebookScope(name: String?) =
         filtersFlow.update { it.copy(notebook = if (it.notebook == name) null else name) }
 
+    /**
+     * Scope the search to one notebook without the toggle semantics of
+     * [setNotebookScope] — the Outline's search action arrives with a file
+     * already in mind, so re-entering the same notebook must keep it pinned
+     * rather than clearing it.
+     */
+    fun pinNotebook(name: String) {
+        filtersFlow.update { it.copy(notebook = name) }
+    }
+
     fun clearFilters() {
         filtersFlow.value = SearchFilters()
     }

--- a/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/vault/VaultViewModels.kt
@@ -411,24 +411,30 @@ class DocumentViewModel(private val app: GroveApplication) : ViewModel() {
     }
 
     /**
-     * Swipe-right quick action: cycle the TODO state like org's shift-cycle,
-     * stepping through every keyword and back to none:
-     * none → active… → done… → none. Plain keyword change (no CLOSED stamp);
-     * use the metadata sheet's DONE chip for org-todo "mark done" semantics.
+     * Swipe-right quick action: set the TODO state to exactly the keyword the
+     * user picked from the state sheet (null = clear it). Picking a done-type
+     * keyword applies full org-todo "mark done" semantics — a repeating
+     * SCHEDULED/DEADLINE advances instead of closing, otherwise a CLOSED stamp
+     * is written — so marking a task done from the outline behaves the same as
+     * from the metadata sheet or the agenda swipe.
      */
-    fun cycleState(headline: OrgHeadline) {
+    fun setState(headline: OrgHeadline, keyword: String?) {
         val loaded = _state.value as? DocumentUiState.Loaded ?: return
         val vault = app.vault.value ?: return
+        if (headline.keyword == keyword) return
         viewModelScope.launch {
-            val next = loaded.document.keywords.next(headline.keyword)
             val (newText, newDoc) = withContext(Dispatchers.Default) {
-                val text = OrgMutations.setKeyword(loaded.document, headline, next)
+                val text = if (keyword != null && loaded.document.keywords.isDone(keyword)) {
+                    OrgMutations.markDone(loaded.document, headline, keyword, LocalDateTime.now())
+                } else {
+                    OrgMutations.setKeyword(loaded.document, headline, keyword)
+                }
                 text to OrgParser.parse(text, loaded.document.keywords)
             }
             _state.value = DocumentUiState.Loaded(loaded.fileName, newDoc)
             vault.save(loaded.fileName, newText)
-            app.syncManager.requestSync("state cycled")
-            showToast("State → ${next ?: "none"}")
+            app.syncManager.requestSync("state set")
+            showToast("State → ${keyword ?: "none"}")
         }
     }
 

--- a/app/src/test/java/com/rrajath/grove/search/QueryMatcherTest.kt
+++ b/app/src/test/java/com/rrajath/grove/search/QueryMatcherTest.kt
@@ -128,6 +128,20 @@ class QueryMatcherTest {
     }
 
     @Test
+    fun `agenda hides done tasks from the day buckets as well as from overdue`() {
+        val openToday = note("OpenToday", keyword = "TODO", scheduled = "<2025-06-11 Wed>")
+        val doneToday = note("DoneToday", keyword = "DONE", done = true, scheduled = "<2025-06-11 Wed>")
+        val doneTomorrow = note("DoneTomorrow", keyword = "DONE", done = true, deadline = "<2025-06-12 Thu>")
+        val donePast = note("DonePast", keyword = "DONE", done = true, scheduled = "<2025-06-01 Sun>")
+
+        val agenda = QueryMatcher.agenda(listOf(openToday, doneToday, doneTomorrow, donePast), 7, today)
+        assertTrue(agenda.overdue.isEmpty())
+        // Tomorrow's only note was done, so that day has no bucket at all.
+        assertEquals(1, agenda.days.size)
+        assertEquals(listOf("OpenToday"), agenda.days[0].notes.map { it.title })
+    }
+
+    @Test
     fun `overdue sorted oldest first then priority then title`() {
         val recentB = note("RecentB", scheduled = "<2025-06-10 Tue>", priority = "B")
         val tiedA = note("TiedA", scheduled = "<2025-06-01 Sun>", priority = "A")

--- a/app/src/test/java/com/rrajath/grove/ui/nav/RoutesTest.kt
+++ b/app/src/test/java/com/rrajath/grove/ui/nav/RoutesTest.kt
@@ -69,6 +69,23 @@ class RoutesTest {
     }
 
     @Test
+    fun `search route carries an optional pinned notebook`() {
+        assertEquals("search?q=", Routes.search())
+        assertEquals("search?q=ramen", Routes.search("ramen"))
+        // The outline's search action pins the notebook with no query typed yet.
+        assertEquals("search?q=&notebook=travel.org", Routes.search(notebook = "travel.org"))
+        assertEquals(
+            "search?q=ramen&notebook=my%20notes.org",
+            Routes.search("ramen", notebook = "my notes.org"),
+        )
+        // Every built form must still match the pattern the NavHost registers.
+        assertEquals(
+            Routes.SEARCH.substringBefore("{"),
+            Routes.search().substringBefore("&"),
+        )
+    }
+
+    @Test
     fun `conflict route encodes notebook id`() {
         assertEquals("conflict/journal.org", Routes.conflict("journal.org"))
     }

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -262,6 +262,7 @@ less-prominent actions.
 | Dismiss / close | `Icons.Default.Close` | — |
 | Sync status — ok | `Icons.Default.Check` | `green` |
 | Sync status — error | `Icons.Default.Warning` | `amber` |
+| Auto-save indicator (editor / capture) | `Icons.Outlined.Save` | `green` saved, `ink3` while dirty |
 | Sync — spinning | `Icons.Default.Sync` (animated) | `ink2` |
 | Scheduled date | `Icons.Default.Schedule` | `blue` |
 | Deadline | `Icons.Default.CalendarToday` | `red` |


### PR DESCRIPTION
Outline
- Top bar gains a ⌕ action between expand/collapse and the overflow menu. It
  opens Search with the notebook facet pinned to the current file (new optional
  `notebook` arg on the search route). Search shows a "searching in <file>" note
  under the field, driven by the live filter: retargeting it in the Filters sheet
  renames the file, widening to all notebooks removes the note.
- The right-swipe "State" action now opens a bottom sheet listing every
  configured TODO and DONE keyword (plus "none") instead of cycling one step per
  tap, so marking a task done is a single tap. Picking a done-type keyword
  applies org "mark done" semantics (repeater advance / CLOSED stamp) rather
  than a bare keyword swap.

Agenda
- Done tasks no longer appear in the day buckets. Overdue already excluded them;
  both sections are now outstanding work only.

Auto-save
- Replaced the green check-mark indicator with an outlined floppy-disk save icon
  in both the note editor and the capture editor. Same green/grey dirty tint and
  double blink on save.
- Fixed characters being swallowed when auto-save fired while typing:
  - EditorViewModel.save() published a state snapshot captured before its I/O,
    rewinding the buffer over anything typed during the write. Writes now go
    through `update`, and `dirty` is recomputed against the text that actually
    reached disk, so in-flight keystrokes survive and get saved by the next tick.
  - The editor mirrored the view-model buffer back into the text field whenever
    the two differed. The field reports its edits a frame late, so that check
    could push the previous buffer over the newest keystrokes. External rewrites
    (metadata sheet) are now signalled by an explicit revision counter.
  - Save/autosave are serialized behind a mutex, and org parsing plus the
    subtree/entry splice moved off the main thread in both the editor and the
    capture view model, so a large notebook can't stall the IME mid-keystroke.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FUjfLvNWVWoeJgUDq5t4fz