### PR TITLE
fix: replace nav slide with the predictive-back fade-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ updated and push.
 
 ## [Unreleased]
 
+### Changed
+- Screen transitions now use the fade-through from the Android predictive-back
+  guidelines instead of a horizontal slide, which had made moving between
+  screens look like swiping through full-screen photos. Dragging back fades the
+  previous screen in and scales it down into place, following the gesture and
+  rewinding if you let go early; going forward mirrors it as a zoom in
+
 ## [1.0.147] - 2026-08-01
 
 ### Added

--- a/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/GroveApp.kt
@@ -1,7 +1,5 @@
 package com.rrajath.grove.ui
 
-import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.DrawerValue
@@ -35,6 +33,10 @@ import com.rrajath.grove.ui.editor.EditNoteScreen
 import com.rrajath.grove.ui.capture.CapturePickerSheet
 import com.rrajath.grove.ui.capture.TemplateEditScreen
 import com.rrajath.grove.ui.nav.Routes
+import com.rrajath.grove.ui.nav.navEnterTransition
+import com.rrajath.grove.ui.nav.navExitTransition
+import com.rrajath.grove.ui.nav.navPopEnterTransition
+import com.rrajath.grove.ui.nav.navPopExitTransition
 import com.rrajath.grove.ui.reminders.ReminderResolveScreen
 import com.rrajath.grove.ui.screens.ConflictScreen
 import com.rrajath.grove.ui.screens.GroveDrawerContent
@@ -59,8 +61,6 @@ import com.rrajath.grove.ui.theme.GroveTheme
 import com.rrajath.grove.ui.theme.grove
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-
-private const val NAV_TRANSITION_MS = 300
 
 @Composable
 fun GroveApp(
@@ -180,21 +180,13 @@ private fun GroveNavigation(
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.grove.bg),
-            // Real (non-None) transitions are required for predictive back: NavHost
-            // wires the system back gesture's progress into these so the previous
-            // screen slides in and is partially visible while the user drags.
-            enterTransition = {
-                slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Left, tween(NAV_TRANSITION_MS))
-            },
-            exitTransition = {
-                slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Left, tween(NAV_TRANSITION_MS))
-            },
-            popEnterTransition = {
-                slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Right, tween(NAV_TRANSITION_MS))
-            },
-            popExitTransition = {
-                slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Right, tween(NAV_TRANSITION_MS))
-            },
+            // Predictive-back fade-through (see ui/nav/NavTransitions.kt). NavHost
+            // seeks these with the system back gesture's progress, so the previous
+            // screen fades in as far as the user has dragged and rewinds on release.
+            enterTransition = navEnterTransition,
+            exitTransition = navExitTransition,
+            popEnterTransition = navPopEnterTransition,
+            popExitTransition = navPopExitTransition,
         ) {
             composable(Routes.ONBOARDING) {
                 OnboardingScreen(

--- a/app/src/main/java/com/rrajath/grove/ui/nav/NavTransitions.kt
+++ b/app/src/main/java/com/rrajath/grove/ui/nav/NavTransitions.kt
@@ -1,0 +1,92 @@
+package com.rrajath.grove.ui.nav
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.navigation.NavBackStackEntry
+
+/**
+ * Route transitions for Grove's full-screen surfaces, following the Android
+ * predictive-back guidelines:
+ * https://developer.android.com/design/ui/mobile/guides/patterns/predictive-back
+ *
+ * The pattern is a fade-through, not a slide. Every Grove route fills the
+ * screen, and sliding one full-screen surface off while another slides on reads
+ * as paging through images rather than as moving between levels of the app.
+ *
+ * Back gesture (pop): the screen being left scales 100% -> 90% and fades out
+ * over the first 35% of the gesture; the previous screen then fades in while it
+ * scales 110% -> 100%. Because both surfaces shrink, the whole scene reads as
+ * one continuous zoom out. Forward navigation mirrors it as a zoom in.
+ *
+ * `NavHost` seeks these transitions with the back gesture's progress, so the
+ * previous screen fades in exactly as far as the user has dragged and rewinds
+ * if they let go before the commit point.
+ */
+
+/**
+ * Full duration of the committed (non-seeked) animation. Matches the
+ * predictive-back commit animation for full-screen surfaces.
+ */
+private const val TOTAL_MS = 450
+
+/**
+ * The guidelines' fade-through threshold: the outgoing surface is fully
+ * transparent at 35% progress, and only then does the incoming one start to
+ * appear, so the two never cross-dissolve over each other.
+ */
+private const val FADE_THROUGH_POINT = 0.35f
+private val FADE_OUT_MS = (TOTAL_MS * FADE_THROUGH_POINT).toInt()
+private val FADE_IN_MS = TOTAL_MS - FADE_OUT_MS
+
+/** The guidelines' fade interpolator: leaves quickly, settles slowly. */
+private val FadeThroughEasing = CubicBezierEasing(0.1f, 0.1f, 0f, 1f)
+
+/**
+ * STANDARD_DECELERATE. The guidelines call for a decelerating curve rather than
+ * raw linear gesture progress, so the surface visibly responds the instant the
+ * drag starts and eases as it approaches the commit point.
+ */
+private val StandardDecelerate = CubicBezierEasing(0f, 0f, 0f, 1f)
+
+/** Scale of a surface at its farthest point "behind" the current one. */
+private const val SCALE_BEHIND = 0.90f
+
+/** Scale of a surface at its farthest point "in front of" the current one. */
+private const val SCALE_AHEAD = 1.10f
+
+private fun fadeThroughIn(fromScale: Float): EnterTransition =
+    fadeIn(tween(FADE_IN_MS, delayMillis = FADE_OUT_MS, easing = FadeThroughEasing)) +
+        scaleIn(
+            initialScale = fromScale,
+            animationSpec = tween(TOTAL_MS, easing = StandardDecelerate),
+        )
+
+private fun fadeThroughOut(toScale: Float): ExitTransition =
+    fadeOut(tween(FADE_OUT_MS, easing = FadeThroughEasing)) +
+        scaleOut(
+            targetScale = toScale,
+            animationSpec = tween(TOTAL_MS, easing = StandardDecelerate),
+        )
+
+/** Forward navigation: the new screen rises from behind into place. */
+val navEnterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition =
+    { fadeThroughIn(SCALE_BEHIND) }
+
+/** Forward navigation: the current screen expands past the viewer and fades. */
+val navExitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition =
+    { fadeThroughOut(SCALE_AHEAD) }
+
+/** Back: the previous screen settles down into place as the gesture is held. */
+val navPopEnterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition =
+    { fadeThroughIn(SCALE_AHEAD) }
+
+/** Back: the current screen shrinks away and fades out first. */
+val navPopExitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition =
+    { fadeThroughOut(SCALE_BEHIND) }

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -258,6 +258,40 @@ Use `Modifier.shadow()` only on the FAB and bottom sheet; everywhere else rely o
 
 ---
 
+## Motion
+
+### Screen transitions: `ui/nav/NavTransitions.kt`
+
+Every Grove route is a full-screen surface, so route changes use the **fade-through**
+from the [Android predictive-back guidelines][pb], never a slide. Sliding one
+full-screen surface off while another slides on reads as paging through images
+rather than as moving between levels of the app.
+
+[pb]: https://developer.android.com/design/ui/mobile/guides/patterns/predictive-back
+
+| | Scale | Opacity |
+|---|---|---|
+| Leaving on back (`popExit`) | 100% → 90% | 100% → 0% over the first 35% |
+| Arriving on back (`popEnter`) | 110% → 100% | 0% → 100%, starting at 35% |
+| Leaving on forward (`exit`) | 100% → 110% | 100% → 0% over the first 35% |
+| Arriving on forward (`enter`) | 90% → 100% | 0% → 100%, starting at 35% |
+
+Because both surfaces shrink on a back and both grow on a forward, the scene reads
+as one continuous zoom rather than a cross-dissolve. Neither screen is visible at the
+35% mark; the `bg` fill behind the `NavHost` shows through.
+
+Full committed duration 450ms. Fades use the guidelines' `CubicBezierEasing(0.1, 0.1, 0, 1)`;
+scale uses `STANDARD_DECELERATE` = `CubicBezierEasing(0, 0, 0, 1)`, since the guidelines
+call for a decelerating curve rather than raw linear gesture progress.
+
+`NavHost` seeks this transition with the system back gesture's progress (the manifest
+opts in via `android:enableOnBackInvokedCallback`), so the previous screen fades in
+exactly as far as the user has dragged and rewinds if they release before the commit
+point. Any new `enterTransition`/`exitTransition` must go through these four values;
+`EnterTransition.None` disables predictive back entirely.
+
+---
+
 ## Icon Conventions
 
 ### Material Icons


### PR DESCRIPTION
The slide transitions added for predictive back read as paging through
full-screen images, because every Grove route is a full-screen surface
and one sliding off while another slides on is exactly that gesture.

Use the full-screen-surface spec from the Android predictive-back
guidelines instead. On back, the screen being left scales 100% -> 90%
and fades out over the first 35% of the gesture; the previous screen
then fades in while scaling 110% -> 100%. Both surfaces shrink, so the
whole scene reads as one continuous zoom out, and forward navigation
mirrors it as a zoom in. Fades use the guidelines' (0.1, 0.1, 0, 1)
curve and scale uses STANDARD_DECELERATE, so the surface responds to
the drag immediately rather than tracking raw linear progress.

NavHost seeks these with the back gesture's progress, so the previous
screen fades in as far as the user has dragged and rewinds on release
before the commit point.

Document the values under a new Motion section in the design system.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Uoz5dN1NCgeEJjuBs4uXP