### PR TITLE
fix: digest task count no longer double-counts timed reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ updated and push.
 
 ## [Unreleased]
 
+### Fixed
+- Reminder digest ("You have X tasks due today") was double-counting tasks
+  that carry an explicit time-of-day: those already get their own individual
+  notification, so the digest now only bundles date-only reminders, matching
+  its intended count
+
 ## [1.0.151] - 2026-08-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ updated and push.
   that carry an explicit time-of-day: those already get their own individual
   notification, so the digest now only bundles date-only reminders, matching
   its intended count
+- Digest count no longer disagrees with Agenda by one when a heading carries
+  both a SCHEDULED and a DEADLINE date landing on the same side of today: it
+  now collapses to a single task the same way Agenda's "a heading belongs to
+  exactly one day" rule does, instead of counting the heading's two reminders
+  table rows separately
 
 ## [1.0.151] - 2026-08-01
 

--- a/app/src/main/java/com/rrajath/grove/reminders/ReminderDigest.kt
+++ b/app/src/main/java/com/rrajath/grove/reminders/ReminderDigest.kt
@@ -22,11 +22,16 @@ object ReminderDigest {
         fun dateOf(r: ReminderEntity): LocalDate =
             Instant.ofEpochMilli(r.triggerAtMillis).atZone(zone).toLocalDate()
 
-        val overdue = reminders.count { dateOf(it).isBefore(today) }
-        val scheduledToday = reminders.count {
+        // Reminders with an explicit time-of-day fire their own "due now" notification
+        // (see ReminderReconciler/ReminderAlarmReceiver); only date-only reminders belong
+        // in the digest, otherwise a timed task gets counted twice.
+        val dateOnly = reminders.filterNot { it.hasExplicitTime }
+
+        val overdue = dateOnly.count { dateOf(it).isBefore(today) }
+        val scheduledToday = dateOnly.count {
             it.planningType == PlanningType.SCHEDULED.storageKey && dateOf(it) == today
         }
-        val deadlineToday = reminders.count {
+        val deadlineToday = dateOnly.count {
             it.planningType == PlanningType.DEADLINE.storageKey && dateOf(it) == today
         }
         return overdue + scheduledToday + deadlineToday

--- a/app/src/main/java/com/rrajath/grove/reminders/ReminderDigest.kt
+++ b/app/src/main/java/com/rrajath/grove/reminders/ReminderDigest.kt
@@ -11,10 +11,12 @@ import java.time.ZoneId
  * date-only reminders (see [ReminderEntity.hasExplicitTime]) fired at the
  * default reminder time.
  *
- * X sums three buckets rather than counting each heading once: overdue +
- * scheduled-today + deadline-today. A heading carrying both a SCHEDULED and a
- * DEADLINE landing on the same day is counted in both buckets, since the
- * reminders table already tracks them as two distinct entries.
+ * X must agree with what the Agenda screen shows for the same set of tasks
+ * (see `AgendaBuckets.whenDate`), so this mirrors its rule: a heading belongs
+ * to exactly one day, its SCHEDULED date if it has one, otherwise its
+ * DEADLINE. A heading carrying both a SCHEDULED and a DEADLINE reminder is
+ * therefore collapsed to one task here too, even though the reminders table
+ * tracks them as two distinct rows.
  */
 object ReminderDigest {
 
@@ -27,13 +29,16 @@ object ReminderDigest {
         // in the digest, otherwise a timed task gets counted twice.
         val dateOnly = reminders.filterNot { it.hasExplicitTime }
 
-        val overdue = dateOnly.count { dateOf(it).isBefore(today) }
-        val scheduledToday = dateOnly.count {
-            it.planningType == PlanningType.SCHEDULED.storageKey && dateOf(it) == today
-        }
-        val deadlineToday = dateOnly.count {
-            it.planningType == PlanningType.DEADLINE.storageKey && dateOf(it) == today
-        }
-        return overdue + scheduledToday + deadlineToday
+        // One SCHEDULED and one DEADLINE row can both belong to the same heading;
+        // collapse them to that heading's single anchor date before counting.
+        val anchorDates = dateOnly
+            .groupBy { Triple(it.fileName, it.headingPath, it.headingLevel) }
+            .mapNotNull { (_, entries) ->
+                val scheduled = entries.firstOrNull { it.planningType == PlanningType.SCHEDULED.storageKey }
+                val deadline = entries.firstOrNull { it.planningType == PlanningType.DEADLINE.storageKey }
+                (scheduled ?: deadline)?.let(::dateOf)
+            }
+
+        return anchorDates.count { !it.isAfter(today) }
     }
 }

--- a/app/src/test/java/com/rrajath/grove/reminders/ReminderDigestTest.kt
+++ b/app/src/test/java/com/rrajath/grove/reminders/ReminderDigestTest.kt
@@ -17,6 +17,7 @@ class ReminderDigestTest {
         date: LocalDate,
         type: PlanningType,
         time: java.time.LocalTime = java.time.LocalTime.of(9, 0),
+        hasExplicitTime: Boolean = false,
     ) = ReminderEntity(
         key = key,
         fileName = "a.org",
@@ -26,6 +27,7 @@ class ReminderDigestTest {
         planningType = type.storageKey,
         triggerAtMillis = LocalDateTime.of(date, time).atZone(zone).toInstant().toEpochMilli(),
         notificationId = ReminderKeys.notificationId(key),
+        hasExplicitTime = hasExplicitTime,
     )
 
     @Test
@@ -58,5 +60,15 @@ class ReminderDigestTest {
     fun `future-only reminders count zero`() {
         val reminders = listOf(entity("future", today.plusDays(1), PlanningType.SCHEDULED))
         assertEquals(0, ReminderDigest.count(reminders, today, zone))
+    }
+
+    @Test
+    fun `reminders with an explicit time are excluded, they fire their own notification`() {
+        val reminders = listOf(
+            entity("timed-overdue", today.minusDays(1), PlanningType.SCHEDULED, hasExplicitTime = true),
+            entity("timed-today", today, PlanningType.DEADLINE, hasExplicitTime = true),
+            entity("date-only-today", today, PlanningType.SCHEDULED),
+        )
+        assertEquals(1, ReminderDigest.count(reminders, today, zone))
     }
 }

--- a/app/src/test/java/com/rrajath/grove/reminders/ReminderDigestTest.kt
+++ b/app/src/test/java/com/rrajath/grove/reminders/ReminderDigestTest.kt
@@ -18,11 +18,12 @@ class ReminderDigestTest {
         type: PlanningType,
         time: java.time.LocalTime = java.time.LocalTime.of(9, 0),
         hasExplicitTime: Boolean = false,
+        headingPath: String = key,
     ) = ReminderEntity(
         key = key,
         fileName = "a.org",
-        headingPath = key,
-        headingTitle = key,
+        headingPath = headingPath,
+        headingTitle = headingPath,
         headingLevel = 1,
         planningType = type.storageKey,
         triggerAtMillis = LocalDateTime.of(date, time).atZone(zone).toInstant().toEpochMilli(),
@@ -43,12 +44,30 @@ class ReminderDigestTest {
     }
 
     @Test
-    fun `a heading scheduled and due today counts in both buckets`() {
+    fun `distinct headings scheduled and due today each count once`() {
         val reminders = listOf(
             entity("sched-today", today, PlanningType.SCHEDULED),
             entity("deadline-today", today, PlanningType.DEADLINE),
         )
         assertEquals(2, ReminderDigest.count(reminders, today, zone))
+    }
+
+    @Test
+    fun `a single heading with both SCHEDULED and DEADLINE due today counts once, matching Agenda`() {
+        val reminders = listOf(
+            entity("task-sched", today, PlanningType.SCHEDULED, headingPath = "task"),
+            entity("task-deadline", today, PlanningType.DEADLINE, headingPath = "task"),
+        )
+        assertEquals(1, ReminderDigest.count(reminders, today, zone))
+    }
+
+    @Test
+    fun `a single heading overdue on both SCHEDULED and DEADLINE counts once`() {
+        val reminders = listOf(
+            entity("task-sched", today.minusDays(3), PlanningType.SCHEDULED, headingPath = "task"),
+            entity("task-deadline", today.minusDays(1), PlanningType.DEADLINE, headingPath = "task"),
+        )
+        assertEquals(1, ReminderDigest.count(reminders, today, zone))
     }
 
     @Test


### PR DESCRIPTION
ReminderDigest.count() bucketed every row in the reminders table, but
reminders with an explicit time-of-day already fire their own individual
notification (ReminderReconciler/ReminderAlarmReceiver). The digest is only
meant to bundle date-only reminders, so timed tasks were inflating the "You
have X tasks due today" count.