### PR TITLE
docs: changelog entry for EditorToolbar icon change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ updated and push.
 
 ## [Unreleased]
 
+### Changed
+- Edit mode's formatting toolbar now draws Bold/Italic/Underline/Code/Checklist as custom
+  vector icons instead of text glyphs (`B`, `I`, `U`, `</>`, `☑`), matching the icon style
+  already used for the rest of the toolbar
+
 ## [1.0.164] - 2026-08-02
 
 ### Changed


### PR DESCRIPTION
The latest commit (0912810) swapped the editor toolbar's text-glyph
buttons for custom vector icons but only changelogged the Note-icon
and app-icon-sync-crash pieces of that commit; add the missing entry
for the toolbar itself.